### PR TITLE
Added sans-serif to font list

### DIFF
--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -15,7 +15,7 @@ module.exports = {
       },
     },
     fontFamily: {
-      sans: ["Poppins", "ui-sans-serif"],
+      sans: ["Poppins", "ui-sans-serif", "sans-serif"],
     },
   },
   safelist: [


### PR DESCRIPTION
I added `sans-serif` to the list of fonts because I noticed that maybe `ui-sans-serif` does not work

![image](https://user-images.githubusercontent.com/51731966/190032113-ec8e14df-3b9c-4f75-b3ee-69bf83a451f2.png)
> I noticed this font while the site was loading