### PR TITLE
removed unused imports and modified props for PageHeader component

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -9,7 +9,7 @@ export interface Props {
   youTubeVideoId?: string;
   hasDivider?: boolean;
   image?: any;
-  alt: string;
+  alt?: string;
 }
 
 const {
@@ -18,7 +18,7 @@ const {
   youTubeVideoId,
   hasDivider = true,
   image,
-  alt,
+  alt = "",
 } = Astro.props;
 ---
 

--- a/src/components/PodiaNewsletter.svelte
+++ b/src/components/PodiaNewsletter.svelte
@@ -23,12 +23,11 @@
 
       if (res.status !== 200) {
         errorMsg = "Subscribe failed. Please try again.";
-      } else {
+        return
+      }
         errorMsg = null;
         successMsg = "You have been subscribed!";
         email = "";
-      }
-      const data = await res.json();
     } catch (err) {
       console.error(err);
     } finally {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,16 +1,7 @@
 ---
 import BaseLayout from "../layouts/BaseLayout.astro";
-import Microsoft from "../images/Microsoft.png";
-import fedex from "../images/fedex.png";
-import PlanetScale from "../images/PlanetScale.png";
-import Auth0 from "../images/Auth0.png";
-import PageHeader from "../components/PageHeader.astro";
-import Bio from "../components/Bio.astro";
-import Divider from "../components/Divider.astro";
-import speaking from "../images/speaking/speaking.jpg";
 import Hero from "../components/Hero.astro";
 import SocialCallout from "../components/SocialCallout.astro";
-import Section from "../components/Section.astro";
 import AboutCallout from "../components/AboutCallout.astro";
 
 export const prerender = true;

--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -3,7 +3,6 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 import { getSortedBlogPosts } from "../utils/contentCollections";
 import Pagination from "../components/Pagination.astro";
 import LinkCardList from "../components/LinkCardList.astro";
-import Hero from "../components/Hero.astro";
 import FeaturedBlogCallout from "../components/FeaturedBlogCallout.astro";
 import Section from "../components/Section.astro";
 


### PR DESCRIPTION
1. Changed the PageHeader.astro component prop types to make the **"alt"** props optional and have a default value if not provided.
2. Modified the **handleOnSubmit** function in PodiaNewsletter.svelte component by removing excess condtional steps.
3. Removed unused imports from about.astro and blog.astro pages