### PR TITLE
Scope 1: Add sample course content structure

### DIFF
--- a/src/content/courses/modern-astro-for-developers/01-foundations/01-what-is-astro.md
+++ b/src/content/courses/modern-astro-for-developers/01-foundations/01-what-is-astro.md
@@ -1,0 +1,36 @@
+---
+slug: what-is-astro
+title: What is Astro?
+moduleSlug: foundations
+moduleTitle: Foundations
+moduleOrder: 1
+lessonOrder: 1
+published: true
+duration: "10m"
+summary: Learn Astro's core concepts and when to use it.
+videoId: ""
+transcript: ""
+resources:
+  - title: Why Astro exists
+    href: https://docs.astro.build/en/concepts/why-astro/
+---
+
+## Why Astro?
+
+Astro is designed to ship less JavaScript by default. Instead of running everything in the browser, it focuses on rendering on the server and sending only the minimum necessary HTML/CSS.
+
+## The core idea
+
+Astro components can be:
+
+- Static (rendered at build time)
+- Partially interactive ("islands" of interactivity)
+
+That gives you great performance characteristics while keeping the flexibility to use your preferred UI framework when you truly need it.
+
+## Key takeaways
+
+- Performance-first defaults
+- Content-friendly rendering model
+- Interactive features added surgically, not wholesale
+

--- a/src/content/courses/modern-astro-for-developers/01-foundations/02-your-first-astro-page.md
+++ b/src/content/courses/modern-astro-for-developers/01-foundations/02-your-first-astro-page.md
@@ -1,0 +1,41 @@
+---
+slug: your-first-astro-page
+title: Your First Astro Page
+moduleSlug: foundations
+moduleTitle: Foundations
+moduleOrder: 1
+lessonOrder: 2
+published: true
+duration: "14m"
+summary: Create a page and understand layout composition in Astro.
+videoId: ""
+transcript: ""
+resources:
+  - title: Astro Pages docs
+    href: https://docs.astro.build/en/core-concepts/astro-pages/
+---
+
+## Build a page
+
+In Astro, a "page" is just a file that exports a component and gets rendered into HTML.
+
+Typical workflow:
+
+1. Create a new page file
+2. Compose it with layouts/components
+3. Add frontmatter metadata for SEO/feeds (when needed)
+
+## Layout composition (mental model)
+
+Think in terms of:
+
+- Layouts: shared shell (header/footer/SEO defaults)
+- Pages: the specific content for a route
+- Components: reusable UI building blocks
+
+## Practice
+
+- Create a simple page
+- Reuse a layout
+- Confirm the output in `astro dev`
+

--- a/src/content/courses/modern-astro-for-developers/02-content-and-routing/01-content-collections-basics.md
+++ b/src/content/courses/modern-astro-for-developers/02-content-and-routing/01-content-collections-basics.md
@@ -1,0 +1,38 @@
+---
+slug: content-collections-basics
+title: Content Collections Basics
+moduleSlug: content-and-routing
+moduleTitle: Content and Routing
+moduleOrder: 2
+lessonOrder: 1
+published: true
+duration: "16m"
+summary: Understand schema validation and content querying with Astro collections.
+videoId: ""
+transcript: ""
+resources:
+  - title: Content collections guide
+    href: https://docs.astro.build/en/guides/content-collections/
+---
+
+## Why content collections matter
+
+When you scale beyond a handful of pages, content becomes a data problem:
+
+- consistent metadata
+- predictable ordering
+- navigation generation
+- safe evolution as requirements change
+
+Astro content collections solve that by combining:
+
+- filesystem-based content
+- schema-based validation (via frontmatter)
+- typed access at build time
+
+## What you'll do in this lesson
+
+- Define a schema for the data you want to rely on
+- Query entries for navigation (course -> module -> lesson)
+- Sort entries using stable ordering fields
+

--- a/src/content/courses/modern-astro-for-developers/02-content-and-routing/02-dynamic-routes-for-courses.mdx
+++ b/src/content/courses/modern-astro-for-developers/02-content-and-routing/02-dynamic-routes-for-courses.mdx
@@ -1,0 +1,43 @@
+---
+slug: dynamic-routes-for-courses
+title: Dynamic Routes for Courses
+moduleSlug: content-and-routing
+moduleTitle: Content and Routing
+moduleOrder: 2
+lessonOrder: 2
+published: true
+duration: "18m"
+summary: Build stable course and lesson URLs from slugs and metadata.
+videoId: ""
+transcript: ""
+resources:
+  - title: Routing guide
+    href: https://docs.astro.build/en/core-concepts/routing/
+---
+
+## Stable URLs from metadata
+
+For long-running courses, URL stability is non-negotiable.
+
+Instead of deriving URLs from file paths alone, you want:
+
+- an explicit `courseSlug`
+- explicit `moduleSlug`
+- explicit `lessonSlug`
+
+Then route generation becomes deterministic even if files move during refactors.
+
+## Suggested URL pattern
+
+Use a nested structure like:
+
+`/courses/{courseSlug}/{moduleSlug}/{lessonSlug}`
+
+## Ordering without surprises
+
+For navigation, rely on:
+
+- `course.order`
+- `moduleOrder` (module-level ordering)
+- `lessonOrder` (lesson-level ordering)
+

--- a/src/content/courses/modern-astro-for-developers/_course.md
+++ b/src/content/courses/modern-astro-for-developers/_course.md
@@ -1,0 +1,24 @@
+---
+slug: modern-astro-for-developers
+title: Modern Astro for Developers
+description: Build a content-driven Astro project with scalable patterns for long-term growth.
+thumbnail: ./thumbnail.png
+tags:
+  - astro
+  - web-development
+  - content-architecture
+level: beginner
+published: false
+order: 1
+---
+
+# Modern Astro for Developers
+
+Welcome! This course teaches the mental model and practical patterns for building content-heavy websites with Astro—so you can ship faster and maintain your codebase for the long haul.
+
+## What you'll learn
+
+- How Astro renders pages and where performance wins come from
+- How to structure content using content collections
+- How to generate stable URLs from course/module/lesson metadata
+


### PR DESCRIPTION
## Summary

Adds a file-based course content structure (course metadata, module folders, and ordered lessons) under `src/content/courses/`.

## Scope

- Scope 1 only: content folder structure + sample Markdown/MDX content
- Does NOT include UI/pages/routing/content collections wiring, video, admin tools, or Podia migration yet

## What was added

- `src/content/courses/modern-astro-for-developers/_course.md`
- 2 modules (`01-foundations`, `02-content-and-routing`)
- 4 lessons total with frontmatter metadata (course/module/lesson slugs, ordering, and future-ready fields like `videoId`, `transcript`, `resources`)

## Test plan

- N/A (content-only). Verify the files exist in the repo and render when wired in Scope 2.

Made with [Cursor](https://cursor.com)