### PR TITLE
Merge chore/migrate-astro-course-lesson-text into feature/built-in-courses

### DIFF
--- a/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/03-upgrading-from-astro-2-0-to-3-0-optional.md
+++ b/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/03-upgrading-from-astro-2-0-to-3-0-optional.md
@@ -15,4 +15,14 @@ resources: []
 
 # Upgrading from Astro 2.0 to 3.0 (optional)
 
-Lesson scaffold only.
+Upgrade docs:
+
+- [https://docs.astro.build/en/guides/upgrade-to/v3/](https://docs.astro.build/en/guides/upgrade-to/v3/)
+
+Breaking changes to know:
+
+- Default port changed from `3000` to `4321`: [https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#changed-default-port-3000](https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#changed-default-port-3000)
+- Removed `@astrojs/image`: [https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#removed-astrojsimage](https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#removed-astrojsimage)
+- Updated image docs: [https://docs.astro.build/en/guides/images/](https://docs.astro.build/en/guides/images/)
+- HTTP request methods case changed (`post` -> `POST`): [https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#changed-http-request-methods-case](https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#changed-http-request-methods-case)
+- Node 16 support removed (requires Node `18.14+`): [https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#removed-support-for-node-16](https://deploy-preview-4166--astro-docs-2.netlify.app/en/guides/upgrade-to/v3/#removed-support-for-node-16)

--- a/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/04-upgrading-from-astro-3-0-to-4-0-optional.md
+++ b/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/04-upgrading-from-astro-3-0-to-4-0-optional.md
@@ -15,4 +15,6 @@ resources: []
 
 # Upgrading from Astro 3.0 to 4.0 (optional)
 
-Lesson scaffold only.
+Upgrade docs:
+
+- [https://docs.astro.build/en/guides/upgrade-to/v4/](https://docs.astro.build/en/guides/upgrade-to/v4/)

--- a/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/05-important-default-port-update.md
+++ b/src/content/courses/modern-websites-with-astro/sections/01-welcome-and-resources/05-important-default-port-update.md
@@ -15,4 +15,20 @@ resources: []
 
 # IMPORTANT - Default Port Update
 
-Lesson scaffold only.
+I originally recorded these videos with Astro 2.0, which used `3000` as the default port. After Astro 3.0, the default port became `4321`. In the videos, you'll see port `3000` used throughout.
+
+For following along, you have two options:
+
+1. Use the default port `4321` (just know yours will differ from the videos).
+2. Set your default port to `3000` in `astro.config.mjs`.
+
+```js
+import { defineConfig } from "astro/config";
+
+// https://astro.build/config
+export default defineConfig({
+  server: {
+    port: 3000,
+  },
+});
+```

--- a/src/content/courses/modern-websites-with-astro/sections/02-intro-to-astro-and-project-setup/11-tailwind-config-file-type.md
+++ b/src/content/courses/modern-websites-with-astro/sections/02-intro-to-astro-and-project-setup/11-tailwind-config-file-type.md
@@ -15,4 +15,7 @@ resources: []
 
 # Tailwind Config File Type
 
-Lesson scaffold only.
+After adding the Tailwind integration, the Tailwind config file may have a different file extension depending on the Astro version used when the project was created.
+
+- Astro 3.0 typically generates `tailwind.config.cjs`
+- Astro 4.0 typically generates `tailwind.config.mjs`

--- a/src/content/courses/modern-websites-with-astro/sections/05-seo-and-meta-tags/07-challenge-implement-category-pagination.md
+++ b/src/content/courses/modern-websites-with-astro/sections/05-seo-and-meta-tags/07-challenge-implement-category-pagination.md
@@ -15,4 +15,9 @@ resources: []
 
 # CHALLENGE: Implement Category Pagination
 
-Lesson scaffold only.
+You have already added pagination for the general listing of blog posts, but what about pagination based on category? If you have many posts for a given category, you likely do not want to load all of that data at once.
+
+Implement category pagination just like you did for general blog posts by either:
+
+- Updating `Pagination.astro`, or
+- Creating a dedicated `CategoryPagination.astro` component.

--- a/src/content/courses/modern-websites-with-astro/sections/05-seo-and-meta-tags/08-final-code-challenge-implemented-category-pagination.md
+++ b/src/content/courses/modern-websites-with-astro/sections/05-seo-and-meta-tags/08-final-code-challenge-implemented-category-pagination.md
@@ -15,4 +15,6 @@ resources: []
 
 # (Final Code) CHALLENGE: Implemented Category Pagination
 
-Lesson scaffold only.
+Final code:
+
+- [https://github.com/jamesqquick/astro-course-demo/tree/ssg/src/pages/category](https://github.com/jamesqquick/astro-course-demo/tree/ssg/src/pages/category)

--- a/src/content/courses/modern-websites-with-astro/sections/07-image-optimization/03-update-adding-og-image-in-layout-for-blog-post-page.md
+++ b/src/content/courses/modern-websites-with-astro/sections/07-image-optimization/03-update-adding-og-image-in-layout-for-blog-post-page.md
@@ -15,4 +15,23 @@ resources: []
 
 # UPDATE - Adding OG Image in Layout for Blog Post Page
 
-Lesson scaffold only.
+When recording originally, one update was missed after integrating the Astro Image component. The OG image passed into the `Layout` component for a blog post page should use the URL produced from frontmatter image data.
+
+```js
+import { Image, getImage } from "astro:assets";
+
+// existing code ...
+
+const coverImageSource = (await getImage({ src: post.data.image })).src;
+```
+
+Then pass that value into the `Layout` component:
+
+```astro
+<Layout title={post.data.title} image={coverImageSource}>
+```
+
+To confirm, navigate to a blog post page and inspect the HTML for the `og:image` property.
+
+View full code in the GitHub repository:
+[https://github.com/jamesqquick/astro-course-demo/blob/ssg/src/pages/blog/%5Bslug%5D.astro](https://github.com/jamesqquick/astro-course-demo/blob/ssg/src/pages/blog/%5Bslug%5D.astro)

--- a/src/content/courses/modern-websites-with-astro/sections/14-dynamic-og-images-with-cloudinary/01-exclusive-cloudinary-offer.md
+++ b/src/content/courses/modern-websites-with-astro/sections/14-dynamic-og-images-with-cloudinary/01-exclusive-cloudinary-offer.md
@@ -1,0 +1,21 @@
+---
+slug: exclusive-cloudinary-offer
+title: EXCLUSIVE Cloudinary Offer!
+moduleSlug: dynamic-og-images-with-cloudinary
+moduleTitle: Dynamic OG Images with Cloudinary
+moduleOrder: 14
+lessonOrder: 1
+published: true
+duration: ""
+summary: ""
+videoId: ""
+transcript: ""
+resources: []
+---
+
+# EXCLUSIVE Cloudinary Offer!
+
+Cloudinary partnered with this course to provide additional free credits.
+
+Use this exclusive signup link to get extra credits:
+[https://cld.media/jqqastro](https://cld.media/jqqastro)

--- a/src/content/courses/modern-websites-with-astro/sections/18-adding-emoji-reactions/01-svelte-integration.md
+++ b/src/content/courses/modern-websites-with-astro/sections/18-adding-emoji-reactions/01-svelte-integration.md
@@ -1,0 +1,21 @@
+---
+slug: svelte-integration
+title: Svelte Integration
+moduleSlug: adding-emoji-reactions
+moduleTitle: Adding Emoji Reactions
+moduleOrder: 18
+lessonOrder: 1
+published: true
+duration: ""
+summary: ""
+videoId: ""
+transcript: ""
+resources: []
+---
+
+# Svelte Integration
+
+If you have not already, add the Svelte integration to your Astro app.
+
+Follow the setup steps in the Astro docs:
+[https://docs.astro.build/en/guides/integrations-guide/svelte/](https://docs.astro.build/en/guides/integrations-guide/svelte/)


### PR DESCRIPTION
## Summary

Merges lesson text/content work from `chore/migrate-astro-course-lesson-text` into `feature/built-in-courses`.

## Notes

- Base: `feature/built-in-courses`
- Compare: `chore/migrate-astro-course-lesson-text`

Please review for conflicts with the built-in course routing and content collection changes on the base branch.

Made with [Cursor](https://cursor.com)