### PR TITLE
feat(images): global Astro image layout and responsive styles

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,6 +9,10 @@ import icon from "astro-icon";
 // https://astro.build/config
 export default defineConfig({
   site: "https://jamesqquick.com/",
+  image: {
+    layout: "constrained",
+    responsiveStyles: true,
+  },
   env: {
     schema: {
       // Secret server variables used in endpoints/components.

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -53,6 +53,7 @@ const {
                 alt={imageAlt}
                 format="webp"
                 loading="eager"
+                priority
                 />
             )
         }


### PR DESCRIPTION
## Summary
- Configure Astro `image.layout: "constrained"` and `image.responsiveStyles: true` so `<Image>` / `<Picture>` and optimizable markdown images get `srcset`, `sizes`, and responsive CSS ([issue #94](https://github.com/jamesqquick/jamesqquick-site/issues/94)).
- Set `priority` on the Hero portrait `<Image>` for LCP / fetch priority (alongside `loading="eager"`).

## Validation
- `npm ci --legacy-peer-deps` (lockfile peer conflict between `@astrojs/tailwind` and Astro 6; same resolution approach as needed for a clean install)
- `npm run build` — succeeded

## Notes
- `npx prisma generate`: **not applicable** — this repo has no Prisma schema.

Closes #94

Made with [Cursor](https://cursor.com)