### PR TITLE
feat(images): phase 3 — WorkExperience, remote patterns, streaming, newsletter

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,10 @@ export default defineConfig({
   image: {
     layout: "constrained",
     responsiveStyles: true,
+    remotePatterns: [
+      { protocol: "https", hostname: "i.ytimg.com" },
+      { protocol: "https", hostname: "**.storage.xata.sh" },
+    ],
   },
   env: {
     schema: {

--- a/src/components/WorkExperience.astro
+++ b/src/components/WorkExperience.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import fedexLight from "../images/company-logos/fedex.png";
 import fedexDark from "../images/company-logos/fedex-dark.png";
 import microsoftLight from "../images/company-logos/microsoft.png";
@@ -22,63 +23,93 @@ const subtitle = "I've worked at some amazing companies";
     class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 items-end place-items-center gap-y-16 gap-x-8 max-x-xl mx-auto"
   >
     <div class="relative flex h-10 w-full max-w-[9rem] items-end justify-center">
-      <img
+      <Image
         class="work-exp-fedex work-exp-fedex--dark-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={fedexLight.src}
+        src={fedexLight}
         alt="FedEx logo"
+        width={fedexLight.width}
+        height={fedexLight.height}
+        sizes="9rem"
       />
-      <img
+      <Image
         class="work-exp-fedex work-exp-fedex--light-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={fedexDark.src}
+        src={fedexDark}
         alt="FedEx logo"
+        width={fedexDark.width}
+        height={fedexDark.height}
+        sizes="9rem"
       />
     </div>
     <div class="relative flex h-10 w-full max-w-[9rem] items-end justify-center">
-      <img
+      <Image
         class="work-exp-microsoft work-exp-microsoft--dark-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={microsoftLight.src}
+        src={microsoftLight}
         alt="Microsoft logo"
+        width={microsoftLight.width}
+        height={microsoftLight.height}
+        sizes="9rem"
       />
-      <img
+      <Image
         class="work-exp-microsoft work-exp-microsoft--light-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={microsoftDark.src}
+        src={microsoftDark}
         alt="Microsoft logo"
+        width={microsoftDark.width}
+        height={microsoftDark.height}
+        sizes="9rem"
       />
     </div>
     <div class="relative flex h-10 w-full max-w-[9rem] items-end justify-center">
-      <img
+      <Image
         class="work-exp-auth0 work-exp-auth0--dark-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={auth0Light.src}
+        src={auth0Light}
         alt="Auth0 logo"
+        width={auth0Light.width}
+        height={auth0Light.height}
+        sizes="9rem"
       />
-      <img
+      <Image
         class="work-exp-auth0 work-exp-auth0--light-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={auth0Dark.src}
+        src={auth0Dark}
         alt="Auth0 logo"
+        width={auth0Dark.width}
+        height={auth0Dark.height}
+        sizes="9rem"
       />
     </div>
     <div class="relative flex h-10 w-full max-w-[9rem] items-end justify-center">
-      <img
+      <Image
         class="work-exp-planetscale work-exp-planetscale--dark-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={planetscaleLight.src}
+        src={planetscaleLight}
         alt="PlanetScale logo"
+        width={planetscaleLight.width}
+        height={planetscaleLight.height}
+        sizes="9rem"
       />
-      <img
+      <Image
         class="work-exp-planetscale work-exp-planetscale--light-theme h-10 w-auto max-w-full object-contain object-bottom"
-        src={planetscaleDark.src}
+        src={planetscaleDark}
         alt="PlanetScale logo"
+        width={planetscaleDark.width}
+        height={planetscaleDark.height}
+        sizes="9rem"
       />
     </div>
     <div class="relative flex h-10 w-full max-w-[11rem] items-end justify-center">
-      <img
+      <Image
         class="work-exp-commerce work-exp-commerce--dark h-10 w-auto max-w-full object-contain object-bottom"
-        src={commerceWhite.src}
+        src={commerceWhite}
         alt="Commerce logo"
+        width={commerceWhite.width}
+        height={commerceWhite.height}
+        sizes="11rem"
       />
-      <img
+      <Image
         class="work-exp-commerce work-exp-commerce--light h-10 w-auto max-w-full object-contain object-bottom"
-        src={commerceBlack.src}
+        src={commerceBlack}
         alt="Commerce logo"
+        width={commerceBlack.width}
+        height={commerceBlack.height}
+        sizes="11rem"
       />
     </div>
   </div>

--- a/src/layouts/StreamingLayout.astro
+++ b/src/layouts/StreamingLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { Image } from "astro:assets";
 import { XATA_API_KEY } from "astro:env/server";
 import { XataClient } from "src/xata";
 import BaseHead from "../components/BaseHead.astro";
@@ -69,9 +70,36 @@ const { title, description, image, includeLogo = false } = Astro.props;
           </div>
           <p class="text-2xl font-bold">{settings?.title}</p>
           <p class="flex items-center justify-end gap-x-4 w-[400px]">
-            <img class="h-10" src={settings?.sponsor1?.logo?.url} />
-            <img class="h-10" src={settings?.sponsor2?.logo?.url} />
-            <img class="h-6" src={settings?.sponsor3?.logo?.url} />
+            {settings?.sponsor1?.logo?.url && (
+              <Image
+                class="h-10 w-auto max-h-10 object-contain"
+                src={settings.sponsor1.logo.url}
+                alt={`Stream sponsor 1${settings?.title ? ` — ${settings.title}` : ""}`}
+                inferSize
+                loading="eager"
+                sizes="160px"
+              />
+            )}
+            {settings?.sponsor2?.logo?.url && (
+              <Image
+                class="h-10 w-auto max-h-10 object-contain"
+                src={settings.sponsor2.logo.url}
+                alt={`Stream sponsor 2${settings?.title ? ` — ${settings.title}` : ""}`}
+                inferSize
+                loading="eager"
+                sizes="160px"
+              />
+            )}
+            {settings?.sponsor3?.logo?.url && (
+              <Image
+                class="h-6 w-auto max-h-6 object-contain"
+                src={settings.sponsor3.logo.url}
+                alt={`Stream sponsor 3${settings?.title ? ` — ${settings.title}` : ""}`}
+                inferSize
+                loading="eager"
+                sizes="120px"
+              />
+            )}
           </p>
         </footer>
       </div>

--- a/src/pages/api/newsletter.astro
+++ b/src/pages/api/newsletter.astro
@@ -38,16 +38,30 @@ const recentYouTubeVideos = await getRecentYouTubeVideos();
 
 <h1>Recent Videos</h1>
 {
-  recentYouTubeVideos.map((video: any) => (
-    <>
-      <h2>
-        <a href={`https://www.youtube.com/watch?v=${video.id}`}>
-          {video.title}
-        </a>
-      </h2>
-      <img src={video.thumbnails.high.url} />
-    </>
-  ))
+  recentYouTubeVideos?.map((video: any) => {
+    const thumb =
+      video.thumbnails?.high ??
+      video.thumbnails?.medium ??
+      video.thumbnails?.default;
+    if (!thumb?.url) return null;
+    return (
+      <>
+        <h2>
+          <a href={`https://www.youtube.com/watch?v=${video.id}`}>
+            {video.title}
+          </a>
+        </h2>
+        <img
+          src={thumb.url}
+          alt={`YouTube thumbnail: ${video.title}`}
+          width={thumb.width ?? 480}
+          height={thumb.height ?? 360}
+          loading="lazy"
+          decoding="async"
+        />
+      </>
+    );
+  })
 }
 <br />
 


### PR DESCRIPTION
## Summary
Closes [#96](https://github.com/jamesqquick/jamesqquick-site/issues/96).

- **WorkExperience:** Company logos use `<Image>` from `astro:assets` with intrinsic dimensions and `sizes` (theme-switching markup preserved).
- **astro.config:** `image.remotePatterns` for YouTube thumbnails (`i.ytimg.com`) and Xata file storage (`**.storage.xata.sh`).
- **StreamingLayout:** Sponsor logos use `<Image>` with `inferSize`, `alt`, and conditional render when URLs exist.
- **Newsletter API:** Video thumbnails get `alt` (title), `width`/`height`, `loading`/`decoding`, and fallback thumbnail sizes.

## Validation
- `npm ci --legacy-peer-deps`, `npm run build` — OK
- `npx prisma generate` — N/A (no Prisma)

## Notes
- `work-with-me.astro` on `main` no longer uses Builder.io imgs; nothing to change there.
- If Xata sponsor URLs use a different host than `*.storage.xata.sh`, add another `remotePatterns` entry.

Closes #96

Made with [Cursor](https://cursor.com)