### PR TITLE
feat(frontend): featured split CTA + BlogCallout wrapper

### DIFF
--- a/src/components/CoursesCallout.astro
+++ b/src/components/CoursesCallout.astro
@@ -36,7 +36,7 @@ const featuredCourse = courses.splice(0, 1)[0];
           description={featuredCourse.data.description!}
           href={getCourseUrl(featuredCourse)}
           date={(featuredCourse.data.updatedDate ?? featuredCourse.data.pubDate)!}
-          showCta={false}
+          ctaText="View course"
           openInNewTab={getCourseHostType(featuredCourse) === "external"}
         />
       </div>

--- a/src/components/FeaturedBlogCallout.astro
+++ b/src/components/FeaturedBlogCallout.astro
@@ -1,49 +1,22 @@
 ---
-import { CollectionEntry } from "astro:content";
+import type { CollectionEntry } from "astro:content";
 import Section from "./Section.astro";
-import { Image } from "astro:assets";
-import Link from "./Link.astro";
-import SplitSection from "./SplitSection.astro";
+import FeaturedSplitSection from "./FeaturedSplitSection.astro";
 
 export interface Props {
   post: CollectionEntry<"blog">;
 }
 
 const { post } = Astro.props as Props;
+const href = `/blog/${post.id}`;
 ---
 
 <Section tone="elevated" paddingY="default">
-  <SplitSection>
-    <a href={`/blog/${post.id}`} slot="left">
-      <Image
-        height={540}
-        width={960}
-        src={post.data.coverImage}
-        class="rounded-2xl"
-        alt={post.data.title}
-      />
-    </a>
-    <div slot="right">
-      <p class="text-lg uppercase text-brand">Featured</p>
-      <a href={`/blog/${post.id}`}>
-        <h2 class="text-3xl font-bold mb-1">{post.data.title}</h2>
-      </a>
-      <p class="text-lg opacity-80 mb-4">
-        {post.data.description}
-      </p>
-      <div class="flex justify-between">
-        <Link isFancy={true}  href={`/blog/${post.id}`}
-          text="Read blog"/>
-        <p class="text-lg opacity-80">
-          {
-            post.data.pubDate.toLocaleDateString("en-us", {
-              year: "numeric",
-              month: "short",
-              day: "numeric",
-            })
-          }
-        </p>
-      </div>
-    </div>
-  </SplitSection>
+  <FeaturedSplitSection
+    image={post.data.coverImage}
+    title={post.data.title}
+    description={post.data.description}
+    href={href}
+    date={post.data.pubDate}
+  />
 </Section>

--- a/src/components/FeaturedSplitSection.astro
+++ b/src/components/FeaturedSplitSection.astro
@@ -13,8 +13,10 @@ export interface Props {
   description: string;
   href: string;
   date: Date;
-  /** When true, shows the fancy “Read blog” link (e.g. blog featured). Courses omit this. */
+  /** When true, shows the fancy CTA link (default label is blog-oriented). */
   showCta?: boolean;
+  /** Label for the fancy CTA; defaults to “Read blog” for blog featured surfaces. */
+  ctaText?: string;
   /** Open image + title links in a new tab (e.g. external course URLs). */
   openInNewTab?: boolean;
 }
@@ -26,6 +28,7 @@ const {
   href,
   date,
   showCta = true,
+  ctaText = "Read blog",
   openInNewTab = false,
 } = Astro.props as Props;
 
@@ -81,7 +84,7 @@ const coverIsPublicUrl = typeof image === "string" && image.startsWith("/");
     >
       {
         showCta ? (
-          <Link isFancy={true} href={href} text="Read blog" />
+          <Link isFancy={true} href={href} text={ctaText} />
         ) : null
       }
       <p class="featured-date text-lg">

--- a/src/pages/courses.astro
+++ b/src/pages/courses.astro
@@ -39,7 +39,7 @@ const formattedCourses = courses.map((course) => ({
           description={featuredCourse.data.description!}
           href={getCourseUrl(featuredCourse)}
           date={(featuredCourse.data.updatedDate ?? featuredCourse.data.pubDate)!}
-          showCta={false}
+          ctaText="View course"
           openInNewTab={getCourseHostType(featuredCourse) === "external"}
         />
       </Section>

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -4,7 +4,6 @@ import { getSortedTalks } from "../../utils/contentCollections";
 import Pagination from "../../components/Pagination.astro";
 import LinkCardList from "../../components/LinkCardList.astro";
 import Hero from "../../components/Hero.astro";
-import FeaturedBlogCallout from "../../components/FeaturedBlogCallout.astro";
 import Section from "../../components/Section.astro";
 import TalkCardList from "../../components/TalkCardList.astro";
 


### PR DESCRIPTION
## Summary
- Closes #100
- Add `ctaText` to `FeaturedSplitSection` (default `Read blog`) so course surfaces can show a course-appropriate label.
- Courses page and `CoursesCallout` now pass `ctaText="View course"` and show the fancy CTA again (previously hidden with `showCta={false}` to avoid wrong copy).
- `FeaturedBlogCallout` is a thin wrapper around `FeaturedSplitSection` + `Section`, removing duplicated split markup.
- Remove unused `FeaturedBlogCallout` import from `talks/index.astro`.

## Validation
- `pnpm install` (worktree)
- `pnpm build`

## Codegen
- N/A (no Prisma/codegen in this repo)

Made with [Cursor](https://cursor.com)