### PR TITLE
feat: dedupe PageHeader and SectionHeader secondary (CenteredSectionHeading)

### DIFF
--- a/src/components/CenteredSectionHeading.astro
+++ b/src/components/CenteredSectionHeading.astro
@@ -1,0 +1,68 @@
+---
+export interface Props {
+  title?: string;
+  subtitle?: string;
+  description?: string;
+}
+const { title, subtitle, description } = Astro.props;
+---
+
+<div class="pb-20 text-center mx-auto">
+  <h1 class="page-header-heading mb-2">
+    <span
+      class="page-header-title block tracking-widest uppercase"
+    >
+      {title}
+    </span>
+    {
+      subtitle && (
+        <span class="page-header-subtitle block mb-2">
+          {subtitle}
+        </span>
+      )
+    }
+  </h1>
+  {description && <p class="page-header-description">{description}</p>}
+</div>
+
+<style>
+  .page-header-heading {
+    font-family: var(--font-display);
+    color: var(--color-text);
+  }
+
+  .page-header-title {
+    color: var(--color-accent);
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    letter-spacing: 0.04em;
+    font-weight: 500;
+  }
+
+  .page-header-subtitle {
+    font-size: 2.25rem;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    font-weight: 700;
+    color: var(--color-text);
+  }
+
+  .page-header-description {
+    font-family: var(--font-sans);
+    font-size: 1.125rem;
+    line-height: 1.56;
+    color: var(--color-text-muted);
+    max-width: 48rem;
+    margin: 0 auto;
+  }
+
+  @media (min-width: 768px) {
+    .page-header-subtitle {
+      font-size: 3rem;
+    }
+
+    .page-header-description {
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,68 +1,12 @@
-    ---
+---
+import CenteredSectionHeading from "./CenteredSectionHeading.astro";
+
 export interface Props {
   title?: string;
   subtitle?: string;
   description?: string;
 }
-const { title, subtitle, description } = Astro.props;
+const props = Astro.props;
 ---
 
-<div class="pb-20 text-center mx-auto">
-  <h1 class="page-header-heading mb-2">
-    <span
-      class="page-header-title block tracking-widest uppercase"
-    >
-      {title}
-    </span>
-    {
-      subtitle && (
-        <span class="page-header-subtitle block mb-2">
-          {subtitle}
-        </span>
-      )
-    }
-  </h1>
-  {description && <p class="page-header-description">{description}</p>}
-</div>
-
-<style>
-  .page-header-heading {
-    font-family: var(--font-display);
-    color: var(--color-text);
-  }
-
-  .page-header-title {
-    color: var(--color-accent);
-    font-size: 1.25rem;
-    line-height: 1.75rem;
-    letter-spacing: 0.04em;
-    font-weight: 500;
-  }
-
-  .page-header-subtitle {
-    font-size: 2.25rem;
-    line-height: 1.15;
-    letter-spacing: -0.02em;
-    font-weight: 700;
-    color: var(--color-text);
-  }
-
-  .page-header-description {
-    font-family: var(--font-sans);
-    font-size: 1.125rem;
-    line-height: 1.56;
-    color: var(--color-text-muted);
-    max-width: 48rem;
-    margin: 0 auto;
-  }
-
-  @media (min-width: 768px) {
-    .page-header-subtitle {
-      font-size: 3rem;
-    }
-
-    .page-header-description {
-      font-size: 1.25rem;
-    }
-  }
-</style>
+<CenteredSectionHeading {...props} />

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,40 +1,23 @@
 ---
-import H2 from './H2.astro';
-
+import CenteredSectionHeading from "./CenteredSectionHeading.astro";
+import H2 from "./H2.astro";
 
 interface Props {
-    title: string;
-    subtitle?: string;
-    description?: string;
-    variant?: "primary" | "secondary";
+  title: string;
+  subtitle?: string;
+  description?: string;
+  variant?: "primary" | "secondary";
 }
 const { title, variant = "primary", subtitle, description } = Astro.props as Props;
 ---
-{variant === "primary" &&(
-  
-    <div class="flex items-center gap-x-10 mb-20">
-  <H2 text={title} classStr="shrink-0" />
-  <div class="h-[0.5px] w-full grow-2 bg-border opacity-50"/>
-  <slot name="cta" />
-</div>
-    )}
+{variant === "primary" && (
+  <div class="flex items-center gap-x-10 mb-20">
+    <H2 text={title} classStr="shrink-0" />
+    <div class="h-[0.5px] w-full grow-2 bg-border opacity-50" />
+    <slot name="cta" />
+  </div>
+)}
 
 {variant === "secondary" && (
-    <div class="pb-20 text-center mx-auto">
-  <h1 class="text-4xl mb-2">
-    <span
-      class="block text-accent text-2xl tracking-widest uppercase font-light"
-    >
-      {title}
-    </span>
-    {
-      subtitle && (
-        <span class="block mb-2 text-4xl leading-[50px] font-bold text-text">
-          {subtitle}
-        </span>
-      )
-    }
-  </h1>
-  {description && <p class="text-xl text-textMuted">{description}</p>}
-</div>
+  <CenteredSectionHeading title={title} subtitle={subtitle} description={description} />
 )}


### PR DESCRIPTION
## Summary
- Add `CenteredSectionHeading.astro` with shared props: `title`, optional `subtitle`, optional `description`, using the same markup and scoped styles as the former `PageHeader`.
- `PageHeader.astro` delegates to `CenteredSectionHeading`.
- `SectionHeader.astro` uses `CenteredSectionHeading` for `variant="secondary"` instead of the duplicated Tailwind block (visual parity with the previous `PageHeader` pattern).

Closes #101

## Validation
- `pnpm run build` (passed)
- `pnpm exec astro check` reports pre-existing project errors unrelated to this change

## Notes
- Secondary section headers now match page header typography/spacing (design tokens) for consistency per the issue.

Made with [Cursor](https://cursor.com)