### PR TITLE
feat(content): shared getStaticPaths helper for blog and talks

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -1,15 +1,12 @@
 ---
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
 import BlogPostLayout from "../../layouts/BlogPostLayout.astro";
+import { getEntryStaticPaths } from "src/utils/contentPaths";
 
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const blogEntries = await getCollection("blog");
-  return blogEntries.map((entry) => ({
-    params: { slug: entry.id },
-    props: { entry },
-  }));
+  return getEntryStaticPaths("blog");
 }
 const { entry } = Astro.props;
 const { Content } = await render(entry);

--- a/src/pages/talks/[slug].astro
+++ b/src/pages/talks/[slug].astro
@@ -1,16 +1,13 @@
 ---
-import { CollectionEntry, getCollection, render } from "astro:content";
+import { CollectionEntry, render } from "astro:content";
 import { Icon } from "astro-icon/components";
 import TalkLayout from "../../layouts/TalkLayout.astro";
+import { getEntryStaticPaths } from "src/utils/contentPaths";
 
 export const prerender = true;
 
 export async function getStaticPaths() {
-  const talkEntries = await getCollection("talk");
-  return talkEntries.map((entry) => ({
-    params: { slug: entry.id },
-    props: { entry },
-  }));
+  return getEntryStaticPaths("talk");
 }
 
 export interface Props {

--- a/src/utils/contentPaths.ts
+++ b/src/utils/contentPaths.ts
@@ -1,0 +1,17 @@
+import type { CollectionEntry } from "astro:content";
+import { getCollection } from "astro:content";
+
+/**
+ * Static paths for a content collection where each entry maps to `params.slug === entry.id`.
+ */
+export async function getEntryStaticPaths<C extends "blog" | "talk">(
+  name: C
+): Promise<
+  { params: { slug: string }; props: { entry: CollectionEntry<C> } }[]
+> {
+  const entries = await getCollection(name);
+  return entries.map((entry) => ({
+    params: { slug: entry.id },
+    props: { entry },
+  }));
+}


### PR DESCRIPTION
## Summary
- Add `getEntryStaticPaths()` in `src/utils/contentPaths.ts` so slug-based content collections share one implementation (`params.slug === entry.id`, `props.entry`).
- Refactor `blog/[...slug].astro` and `talks/[slug].astro` to use the helper.

**Note:** The repo does not have `src/pages/courses/[...slug].astro`; courses use `course/[courseSlug].astro` and lesson routes instead. The helper is typed for `blog` and `talk`; extending it for other collections is straightforward if a matching route is added later.

Closes #102

## Validation
- `pnpm build` (succeeds; blog and talks prerender as before)
- `pnpm exec astro check` reports existing project errors (Xata overlays, etc.); none introduced by this change

## Codegen
- N/A (no Prisma/codegen in this repo for this change)

Made with [Cursor](https://cursor.com)