### PR TITLE
feat(content): centralize courses marketing copy

### DIFF
--- a/src/components/CoursesCallout.astro
+++ b/src/components/CoursesCallout.astro
@@ -4,14 +4,15 @@ import FeaturedSplitSection from "@components/FeaturedSplitSection.astro";
 import { getCourseCatalog, getCourseHostType, getCourseUrl } from "src/utils/contentCollections";
 import SectionHeader from "@components/SectionHeader.astro";
 import { Image } from "astro:assets";
+import {
+  COURSES_DESCRIPTION,
+  COURSES_HERO_TITLE,
+  COURSES_SUBTITLE,
+} from "src/content/coursesMeta";
 
 /** Public files under `public/` — use `<img>` so we do not depend on the Astro image pipeline for static URLs. */
 
 export const prerender = true;
-
-const title = "Courses";
-const subtitle = `Learn to build for the modern web`;
-const description = `Looking to take your web development skills to the next level? Check out my collection of courses, offering something for everyone whether you're a seasoned developer or just getting started.`;
 
 const courses = (await getCourseCatalog())
   .filter(
@@ -25,7 +26,12 @@ const featuredCourse = courses.splice(0, 1)[0];
 ---
 
 <Section paddingY="spacious">
-  <SectionHeader title={title} subtitle={subtitle} description={description} variant="secondary" />
+  <SectionHeader
+    title={COURSES_HERO_TITLE}
+    subtitle={COURSES_SUBTITLE}
+    description={COURSES_DESCRIPTION}
+    variant="secondary"
+  />
 
   {
     featuredCourse && (

--- a/src/content/coursesMeta.ts
+++ b/src/content/coursesMeta.ts
@@ -1,0 +1,10 @@
+/** Shared marketing copy for the courses page and home callout. */
+
+export const COURSES_HERO_TITLE = "Courses";
+
+export const COURSES_SUBTITLE = "Learn to build for the modern web";
+
+export const COURSES_DESCRIPTION =
+  "Looking to take your web development skills to the next level? Check out my collection of courses, offering something for everyone whether you're a seasoned developer or just getting started.";
+
+export const COURSES_PAGE_TITLE = "Courses | James Q Quick";

--- a/src/pages/courses.astro
+++ b/src/pages/courses.astro
@@ -6,12 +6,14 @@ import FeaturedSplitSection from "@components/FeaturedSplitSection.astro";
 import { getCourseCatalog, getCourseHostType, getCourseUrl } from "src/utils/contentCollections";
 import SectionHeader from "@components/SectionHeader.astro";
 import LinkCardList from "@components/LinkCardList.astro";
+import {
+  COURSES_DESCRIPTION,
+  COURSES_HERO_TITLE,
+  COURSES_PAGE_TITLE,
+  COURSES_SUBTITLE,
+} from "src/content/coursesMeta";
 
 export const prerender = true;
-
-const title = "Courses";
-const subtitle = `Learn to build for the modern web`;
-const description = `Looking to take your web development skills to the next level? Check out my collection of courses, offering something for everyone whether you're a seasoned developer or just getting started.`;
 
 const courses = (await getCourseCatalog()).filter(
   (course) => course.data.coverImage && course.data.description && (course.data.updatedDate ?? course.data.pubDate)
@@ -28,8 +30,13 @@ const formattedCourses = courses.map((course) => ({
 
 ---
 
-<BaseLayout title="Courses | James Q Quick">
-  <HeroSection title={title} subtitle={subtitle} description={description} hasFullHeight={false} />
+<BaseLayout title={COURSES_PAGE_TITLE}>
+  <HeroSection
+    title={COURSES_HERO_TITLE}
+    subtitle={COURSES_SUBTITLE}
+    description={COURSES_DESCRIPTION}
+    hasFullHeight={false}
+  />
   {
     featuredCourse && (
       <Section tone="elevated" paddingY="default">


### PR DESCRIPTION
## Summary
- Add `src/content/coursesMeta.ts` exporting `COURSES_HERO_TITLE`, `COURSES_SUBTITLE`, `COURSES_DESCRIPTION`, and `COURSES_PAGE_TITLE`.
- Wire `courses.astro` and `CoursesCallout.astro` to import these constants so copy stays in sync.

Fixes #103

## Validation
- `npm run build` (passed)
- `npx astro check` reports pre-existing project errors unrelated to this change; build is clean.

## Notes
- Codegen: N/A (no Prisma/codegen in scope)

Made with [Cursor](https://cursor.com)