### PR TITLE
fix: speaker form input text invisible in dark mode

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -17,11 +17,13 @@ module.exports = {
         accentHover: "var(--color-accent-hover)",
         text: "var(--color-text)",
         textMuted: "var(--color-text-muted)",
+        "text-subtle": "var(--color-text-subtle)",
         bg: "var(--legacy-bg)",
         bgDark: "var(--legacy-bg-dark)",
         bgLight: "var(--legacy-bg-light)",
         bgLightBrand: "var(--legacy-bg-light-brand)",
         surface: "var(--color-surface)",
+        "surface-hover": "var(--color-surface-hover)",
         border: "var(--color-border)",
         /* Legacy alias to avoid breaking existing classes */
         brand: "var(--legacy-brand)",


### PR DESCRIPTION
## Summary

- Adds missing `surface-hover` and `text-subtle` color token mappings to the Tailwind config
- Fixes dark mode input text being invisible on the speaker request form (and other components using `bg-surface-hover`)

## Problem

The `bg-surface-hover` Tailwind class used on form inputs was not resolving because `surface-hover` was not defined in the Tailwind color config. This caused inputs to fall back to the browser's default white background, while the dark mode text color (`text-text` = `#f8fafc`, near-white) rendered invisible against it.

Similarly, `placeholder:text-text-subtle` was not resolving due to the missing `text-subtle` color mapping.

## Fix

Added the missing CSS variable mappings to `tailwind.config.mjs`:
- `"surface-hover": "var(--color-surface-hover)"` — resolves to `#17203a` in dark / `#f2f5fa` in light
- `"text-subtle": "var(--color-text-subtle)"` — resolves to `#94a3b8` in dark / `#6b7280` in light

This also fixes `bg-surface-hover` usage in course pages and the sidebar component.