### PR TITLE
feat: reduce unused CSS by pruning safelist, icons, prose, and fonts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,7 +39,6 @@ export default defineConfig({
     svelte(),
     icon({
       include: {
-        // Include only three `mdi` icons in the bundle
         mdi: [
           "close",
           "account-plus",
@@ -53,6 +52,13 @@ export default defineConfig({
           "download",
           "chart-bar",
           "monitor",
+        ],
+        teenyicons: [
+          "youtube-outline",
+          "twitter-outline",
+          "tiktok-outline",
+          "discord-outline",
+          "twitch-outline",
         ],
       },
     }),

--- a/src/layouts/BaseLayoutWithProse.astro
+++ b/src/layouts/BaseLayoutWithProse.astro
@@ -27,7 +27,7 @@ const { title, description, image } = Astro.props;
     <div class="flex flex-col min-h-screen py-4">
       <Navbar />
       <div class="px-8 mx-auto grow w-full">
-        <main class="container mx-auto flex-1 max-w-4xl prose prose-xl">
+        <main class="container mx-auto flex-1 max-w-4xl ds-prose">
           <slot />
         </main>
       </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,6 @@
 @import "@fontsource-variable/inter";
 @import "@fontsource-variable/space-grotesk";
 @import "@fontsource/ibm-plex-mono/400.css";
-@import "@fontsource/ibm-plex-mono/500.css";
 @import "@fontsource/ibm-plex-mono/700.css";
 
 @media screen and (max-width: 1024px) {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -77,17 +77,8 @@ module.exports = {
   },
   safelist: [
     "text-youtube",
-    "text-instagram",
-    "text-facebook",
-    "text-twitch",
-    "text-twitter",
-    "text-linkedin",
     "h-[0.5px]",
-    "h-[1px]",
     "h-[2px]",
-    "h-[4px]",
-    "transition-all",
-    "bottom-8",
   ],
   plugins: [require("@tailwindcss/typography")],
 };


### PR DESCRIPTION
## Summary
- **Tailwind safelist cleanup**: Removed 8 unused classes (`text-instagram`, `text-facebook`, `text-twitch`, `text-twitter`, `text-linkedin`, `h-[1px]`, `h-[4px]`, `bottom-8`). Also removed `transition-all` since it appears in source files and Tailwind tree-shakes it without the safelist. Kept `text-youtube`, `h-[0.5px]`, and `h-[2px]` which are actively used.
- **Icon filtering**: Added explicit `include` filter for `teenyicons` icon set (5 icons: youtube, twitter, tiktok, discord, twitch outlines). The `mdi` set already had this but teenyicons was unfiltered.
- **Prose consolidation**: Replaced raw `prose prose-xl` in `BaseLayoutWithProse` with the `ds-prose` class, which already applies `prose prose-xl` plus all the custom typography overrides from `global.css`. This avoids generating duplicate prose utility rules.
- **Font weight reduction**: Removed IBM Plex Mono weight 500 (medium) import. Only weights 400 (regular) and 700 (bold) are used — mono font appears in `prose-code`/`prose-pre` contexts and `FileTree.astro`, none of which use medium weight.

## Validation
- `pnpm run build` — completed successfully with no errors

## Notes
- The ~568 KiB "unused JavaScript" flagged by Lighthouse was from the Keeper Password Manager Chrome extension (`chrome-extension://` URLs), not from the site itself
- The remaining unused CSS (~12 KiB) was from this single bundled stylesheet. These changes should reduce the unused portion, though some residual unused rules from `@tailwindcss/typography` are expected since not every prose style is used on every page.