### PR TITLE
fix: increase kicker/eyebrow text size for readability

### DIFF
--- a/src/components/CenteredSectionHeading.astro
+++ b/src/components/CenteredSectionHeading.astro
@@ -34,8 +34,8 @@ const { title, subtitle, description } = Astro.props;
   .page-header-title {
     font-family: var(--font-mono);
     color: var(--color-accent);
-    font-size: 0.6875rem;
-    line-height: 1rem;
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
     letter-spacing: 0.08em;
     font-weight: 400;
   }

--- a/src/components/CenteredSectionHeading.astro
+++ b/src/components/CenteredSectionHeading.astro
@@ -34,8 +34,8 @@ const { title, subtitle, description } = Astro.props;
   .page-header-title {
     font-family: var(--font-mono);
     color: var(--color-accent);
-    font-size: 0.8125rem;
-    line-height: 1.25rem;
+    font-size: 0.9375rem;
+    line-height: 1.375rem;
     letter-spacing: 0.08em;
     font-weight: 400;
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,8 +61,8 @@ h1 {
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 0.6875rem;
-  line-height: 1rem;
+  font-size: 0.8125rem;
+  line-height: 1.25rem;
   font-weight: 400;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,8 +61,8 @@ h1 {
   font-family: var(--font-mono);
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  font-size: 0.8125rem;
-  line-height: 1.25rem;
+  font-size: 0.9375rem;
+  line-height: 1.375rem;
   font-weight: 400;
 }
 


### PR DESCRIPTION
## Summary
- Increases the kicker/eyebrow text size from `0.6875rem` (11px) to `0.8125rem` (13px) and line-height from `1rem` to `1.25rem`
- Affects the `.ds-kicker` global class and the `.page-header-title` scoped style in `CenteredSectionHeading.astro`
- Labels like "COURSES", "TESTIMONIALS", "EXPERTISE", etc. were too small to read comfortably

## Files changed
- `src/styles/global.css` — `.ds-kicker` font-size and line-height
- `src/components/CenteredSectionHeading.astro` — `.page-header-title` font-size and line-height (same values, defined separately in scoped styles)

## Validation
- `pnpm run build` passes