### PR TITLE
fix: update footer hosting link from Netlify to Cloudflare

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -29,7 +29,7 @@ import Section from "./Section.astro";
       </span>
       <span>
         Hosted on{" "}
-        <Link href="https://netlify.com/" text="Netlify" classStr="font-bold pb-1" isFancy={false} />
+        <Link href="https://cloudflare.com/" text="Cloudflare" classStr="font-bold pb-1" isFancy={false} />
       </span>
     </div>
   </footer>


### PR DESCRIPTION
## Summary
- Updates the "Hosted on" link in the footer from Netlify to Cloudflare to reflect the current hosting provider.