### PR TITLE
refactor: centralize testimonial collection access via getTestimonials helper

### DIFF
--- a/src/components/SpeakingCallout.astro
+++ b/src/components/SpeakingCallout.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import speaking from "../images/speaking/speaking.jpg";
 import Button, { ButtonType } from "./Button.astro";
 import Testimonial from "./speaking/Testimonial.astro";
+import { getTestimonials } from "../utils/contentCollections";
 
-const testimonials = await getCollection("testimonial");
+const testimonials = await getTestimonials();
 ---
 
 <section class="bg-section-elevated px-2">

--- a/src/components/Testimonials.astro
+++ b/src/components/Testimonials.astro
@@ -1,10 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import CarouselNavButton from "./CarouselNavButton.astro";
 import Section from "./Section.astro";
 import Testimonial from "./speaking/Testimonial.astro";
+import { getTestimonials } from "../utils/contentCollections";
 
-const testimonials = await getCollection("testimonial");
+const testimonials = await getTestimonials();
 const count = testimonials.length;
 ---
 

--- a/src/utils/contentCollections.ts
+++ b/src/utils/contentCollections.ts
@@ -241,6 +241,12 @@ export const getLessonByRoute = async (
   });
 };
 
+export const getTestimonials = async (): Promise<
+  CollectionEntry<"testimonial">[]
+> => {
+  return getCollection("testimonial");
+};
+
 export const getSortedTalks = async (): Promise<CollectionEntry<"talk">[]> => {
   return (await getCollection("talk")).sort(
     (a, b) =>


### PR DESCRIPTION
## Summary
- Adds `getTestimonials()` helper to `src/utils/contentCollections.ts`, consistent with existing helpers like `getSortedBlogPosts()` and `getSortedTalks()`
- Refactors `Testimonials.astro` and `SpeakingCallout.astro` to use the new helper instead of calling `getCollection("testimonial")` directly

## Validation
- `pnpm build` passes
- Speaking page still renders `<Testimonials />` and `<SpeakingCallout />` unchanged

Closes #104