### PR TITLE
feat: replace Resend email sending with Cloudflare Email Service binding

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,11 +64,6 @@ export default defineConfig({
       },
     }),
   ],
-  vite: {
-    ssr: {
-      external: ["resend", "sanitize-html", "markdown-it"],
-    },
-  },
   output: "server",
   adapter: cloudflare(),
   experimental: {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -18,7 +18,8 @@ export default defineConfig({
   },
   env: {
     schema: {
-      // Secret server variables used in endpoints/components.
+      // Resend is only used for audience/contact management (newsletter subscriptions).
+      // Transactional email sending uses the Cloudflare Email Service binding instead.
       // Marked optional to keep local builds from failing when env vars are absent.
       RESEND_API_KEY: envField.string({
         context: "server",
@@ -63,6 +64,11 @@ export default defineConfig({
       },
     }),
   ],
+  vite: {
+    ssr: {
+      external: ["resend", "sanitize-html", "markdown-it"],
+    },
+  },
   output: "server",
   adapter: cloudflare(),
   experimental: {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -4,5 +4,6 @@
 declare module "cloudflare:workers" {
   interface CloudflareEnv {
     COURSE_BUCKET: R2Bucket;
+    EMAIL: SendEmail;
   }
 }

--- a/src/utils/emailer.ts
+++ b/src/utils/emailer.ts
@@ -1,6 +1,23 @@
 import { Resend } from "resend";
+import { env } from "cloudflare:workers";
 import { RESEND_API_KEY, RESEND_AUDIENCE_ID } from "astro:env/server";
 
+export const sendEmail = async (
+  fromEmail: string,
+  text: string,
+  subject: string
+) => {
+  await env.EMAIL.send({
+    to: "me@jamesqquick.com",
+    from: "speaking@jamesqquick.com",
+    replyTo: fromEmail,
+    subject,
+    text,
+  });
+};
+
+// Resend is still used for audience/contact management since
+// Cloudflare Email Service doesn't have a contacts API.
 let resend: Resend | null = null;
 
 const getResendClient = () => {
@@ -11,20 +28,6 @@ const getResendClient = () => {
     resend = new Resend(RESEND_API_KEY);
   }
   return resend;
-};
-
-export const sendEmail = async (
-  fromEmail: string,
-  text: string,
-  subject: string
-) => {
-  await getResendClient().emails.send({
-    to: "me@jamesqquick.com",
-    from: "speaking@jamesqquick.com",
-    replyTo: fromEmail,
-    subject,
-    text,
-  });
 };
 
 export const addContact = async (email: string) => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,6 +8,11 @@
     "directory": "./dist",
     "not_found_handling": "404-page"
   },
+  "send_email": [
+    {
+      "name": "EMAIL"
+    }
+  ],
   "r2_buckets": [
     {
       "binding": "COURSE_BUCKET",


### PR DESCRIPTION
## Summary
- Replaces transactional email sending (speaking form) with the native Cloudflare Email Service `send_email` binding, removing the dependency on Resend for this path
- Keeps Resend only for newsletter audience/contact management (`addContact`)
- Adds `EMAIL` (`SendEmail`) binding to `wrangler.jsonc` and `CloudflareEnv` type
- Adds `vite.ssr.external` config to fix `module is not defined` SSR error caused by CJS deps (`resend`/`svix`) being inlined into the workerd environment

## Changes
- `wrangler.jsonc` — added `send_email` binding with name `EMAIL`
- `src/env.d.ts` — added `EMAIL: SendEmail` to `CloudflareEnv`
- `src/utils/emailer.ts` — `sendEmail()` now uses `env.EMAIL.send()` via `cloudflare:workers`; Resend client is only used by `addContact()`
- `astro.config.mjs` — updated env schema comments; added `vite.ssr.external` for CJS deps

## Before merging
- Onboard `jamesqquick.com` to Cloudflare Email Service (Dashboard > Compute & AI > Email Service > Onboard Domain)
- Add SPF/DKIM DNS records as prompted by the onboarding flow