### PR TITLE
ci: disable automatic lighthouse audit trigger

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,8 +1,7 @@
 name: Lighthouse CI
 
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch: # Trigger manually only; automatic PR runs disabled
 
 jobs:
   lighthouse:


### PR DESCRIPTION
## Summary
- Replaced the `pull_request` trigger in `.github/workflows/lighthouse.yml` with `workflow_dispatch`
- The workflow infrastructure (build, wrangler dev, Lighthouse CI action, config) is fully intact
- The audit can still be run manually from the GitHub Actions UI when needed

## Validation
- Only the workflow trigger was changed; no application code was touched

## Notes
- `.lighthouserc.cjs` is untouched — re-enabling is a one-line change