### PR TITLE
feat: reduce vertical spacing on blog page hero

### DIFF
--- a/src/pages/blog.astro
+++ b/src/pages/blog.astro
@@ -26,7 +26,7 @@ const formattedPosts = posts.map((post) => ({
     title="Blog"
     hasFullHeight={false}
     size="large"
-    classStr="py-10 md:py-12 lg:py-14"
+    classStr="pt-10 pb-4 md:pt-12 md:pb-6 lg:pt-14 lg:pb-8"
     subtitle="Articles for web developers!"
     description="I write about modern web development, developer experience, careers, and more!"
     h1AriaLabel="Blog | James Q Quick"
@@ -40,7 +40,7 @@ const formattedPosts = posts.map((post) => ({
     date={featuredPost.data.pubDate}
   />
   </Section> -->
-  <Section tone="base" classStr="mt-8">
+  <Section tone="base" paddingY="compact">
     <LinkCardList items={formattedPosts} />
   </Section>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- Reduced the vertical gap between the blog page hero and the first row of post cards
- Hero bottom padding tightened (`pb-4 md:pb-6 lg:pb-8`) while keeping the same top padding
- Replaced `Section` `mt-8 + default` padding with `paddingY="compact"` for a tighter top edge

On desktop, the gap from the hero description to the cards drops from ~280px to ~144px (~49% reduction).

## Validation
- `pnpm run build` — exit 0
- Visually verified by serving `dist/client` on a static server

## Notes
- Same approach (split `py-*` into `pt-*` + `pb-*`) could be applied to other hero pages if we want consistent tightening, but this PR only touches the blog page as requested.