### PR TITLE
feat: remove image from blog card

### DIFF
--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -1,20 +1,5 @@
 ---
 import { getFormattedDate } from "../utils/dates";
-import javascript from "../images/blog/logos/javascript.png";
-import react from "../images/blog/logos/react.png";
-import sveltekit from "../images/blog/logos/sveltekit.png";
-import vscode from "../images/blog/logos/vscode.png";
-import nodejs from "../images/blog/logos/nodejs.png";
-import chatgpt from "../images/blog/logos/chatgpt.png";
-import { Image } from "astro:assets";
-
-/** ESM metadata from `image()` collections, or site-root URL in `public/` */
-type ImageLike = {
-  src: string;
-  width: number;
-  height: number;
-  format?: string;
-};
 
 export interface Props {
   slug: string;
@@ -25,44 +10,13 @@ export interface Props {
   tag?: string;
   openInNewTab?: boolean;
   dateLabelPrefix?: string;
-  image: ImageLike | string;
 }
 
-const { slug, date, title, btnText = "Read", tag, image, description, openInNewTab = false, dateLabelPrefix = "" } =
+const { slug, date, title, tag, description, openInNewTab = false, dateLabelPrefix = "" } =
   Astro.props;
-
-const isPublicUrl = typeof image === "string" && image.startsWith("/");
-const tagToLogo = {
-  javascript,
-  vscode,
-  sveltekit,
-  react,
-  nodejs,
-  chatgpt,
-};
 ---
 
 <div class="card-shell overflow-hidden" data-interactive>
-  <div class="flex items-center justify-center w-full object-cover mb-4">
-    <a href={slug} class="grow hover:underline" target={openInNewTab ? "_blank" : undefined} rel={openInNewTab ? "noopener noreferrer" : undefined}>
-      {
-        isPublicUrl ? (
-          <img src={image as string} alt={title} class="card-image aspect-video object-cover" loading="lazy" decoding="async" />
-        ) : (
-          <Image
-            height={(image as ImageLike).height}
-            width={(image as ImageLike).width}
-            format="webp"
-            quality={80}
-            src={image as ImageLike}
-            alt={title}
-            class="card-image aspect-video object-cover"
-          />
-        )
-      }
-    </a>
-  </div>
-
   {tag && <span class="card-chip mb-2 inline-flex">{tag}</span>}
   <p class="mb-1 card-date">{dateLabelPrefix}{getFormattedDate(date)}</p>
   <a href={slug} class="grow hover:underline" target={openInNewTab ? "_blank" : undefined} rel={openInNewTab ? "noopener noreferrer" : undefined}>
@@ -76,16 +30,6 @@ const tagToLogo = {
     <p class="card-description">{description}</p>
   )}
 </div>
-<!-- {
-        tag && tagToLogo[tag] && (
-          <Image
-            src={tagToLogo[tag]}
-            alt={`Cover`}
-            class="invisible md:visible w-8 lg:w-16 "
-          />
-        )
-      } -->
-<!-- </div> -->
 
 <style>
   .card-shell {
@@ -104,10 +48,6 @@ const tagToLogo = {
     transform: translateY(-2px);
     box-shadow: var(--shadow-lg);
     border-color: var(--color-accent);
-  }
-
-  .card-image {
-    border-radius: calc(var(--radius-card) - 4px);
   }
 
   .card-chip {

--- a/src/components/LinkCardList.astro
+++ b/src/components/LinkCardList.astro
@@ -6,14 +6,7 @@ export interface Props {
     id: string;
     title: string;
     date: Date;
-    image:
-      | string
-      | {
-          src: string;
-          width: number;
-          height: number;
-          format?: string;
-        };
+    image?: string | { src: string; width: number; height: number; format?: string };
     description?: string;
     tags?: string[];
     link: string;
@@ -36,7 +29,6 @@ const { items, includeDescription, dateLabelPrefix } = Astro.props;
         slug={item.link}
         openInNewTab={item.openInNewTab}
         tag={item?.tags ? item.tags[0] : undefined}
-        image={item.image}
         description={includeDescription ? item.description : undefined}
         dateLabelPrefix={dateLabelPrefix}
       />


### PR DESCRIPTION
## Summary
- Removed the image block from `LinkCard.astro` since the cover image now includes the post title
- Cleaned up unused imports (`Image`, logo assets), removed the `image` prop and `isPublicUrl` variable, and deleted the `.card-image` CSS rule
- Updated `LinkCardList.astro` to make `image` optional in its item type and removed the prop passthrough to `LinkCard`

## Validation
- `pnpm run build` — pre-existing env issues in both main and worktree (missing workerd binary, unrelated MDX import errors); no new errors introduced

## Notes
- No call sites pass a required `image` prop anymore; `LinkCardList` still accepts `image` as optional on its items type for backward compatibility with existing data shapes