### PR TITLE
feat: add fancy animated hover to prose links

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -82,7 +82,7 @@ p {
 }
 
 .ds-prose a:hover {
-  color: var(--color-bg);
+  color: var(--color-bg) !important;
   z-index: 1;
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,9 +47,51 @@ p {
   @apply prose-h2:text-accent prose-h3:text-text prose-h4:text-text;
   @apply prose-p:text-textMuted prose-li:text-textMuted;
   @apply prose-strong:text-text;
-  @apply prose-a:text-accent;
+  @apply prose-a:text-text prose-a:no-underline;
   @apply prose-code:font-mono prose-pre:font-mono;
   @apply prose-img:rounded-lg;
+}
+
+/* Fancy hover fill for prose links — mirrors Link.astro .link-fancy */
+.ds-prose a {
+  position: relative;
+  display: inline-block;
+  padding-inline: 0.35em;
+  padding-block: 0.2em;
+  line-height: 1.45;
+  color: var(--color-text);
+}
+
+.ds-prose a::after {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  left: 0;
+  right: 0;
+  bottom: 0.12em;
+  height: 1px;
+  border-radius: var(--radius-button);
+  background: var(--color-text);
+  pointer-events: none;
+  transition:
+    left var(--duration-normal) var(--ease-out),
+    right var(--duration-normal) var(--ease-out),
+    bottom var(--duration-normal) var(--ease-out),
+    height var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out);
+}
+
+.ds-prose a:hover {
+  color: var(--color-bg);
+  z-index: 1;
+}
+
+.ds-prose a:hover::after {
+  left: -0.125rem;
+  right: -0.125rem;
+  bottom: 0;
+  height: 100%;
+  background: var(--color-accent);
 }
 
 h1 {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -55,6 +55,7 @@ p {
 /* Fancy hover fill for prose links — mirrors Link.astro .link-fancy */
 .ds-prose a {
   position: relative;
+  isolation: isolate;
   display: inline-block;
   padding-inline: 0.35em;
   padding-block: 0.2em;
@@ -65,7 +66,7 @@ p {
 .ds-prose a::after {
   content: "";
   position: absolute;
-  z-index: 0;
+  z-index: -1;
   left: 0;
   right: 0;
   bottom: 0.12em;
@@ -82,7 +83,7 @@ p {
 }
 
 .ds-prose a:hover {
-  color: var(--color-bg) !important;
+  color: var(--color-bg);
   z-index: 1;
 }
 


### PR DESCRIPTION
## What

Applies the `Link.astro` fancy hover effect (expanding background fill) to all markdown-generated `<a>` tags within `ds-prose` content — blog posts, talks, and course descriptions.

## How

Uses a `::after` pseudo-element on `.ds-prose a` to replicate the `.link-fancy` behavior from `Link.astro`:

- **Resting state**: text-colored thin 1px underline at the bottom of the link
- **Hover state**: underline expands upward to a full rounded accent-colored fill behind the text, text color inverts to background

Also changes the prose link resting color from `text-accent` (green) to `text-text` (standard text color) to match the `Link.astro` component convention.

## Scope

- **1 file changed**: `src/styles/global.css`
- Affects all `ds-prose` contexts (blog posts, talks, course pages)
- Uses existing design tokens (`--duration-normal`, `--ease-out`, `--radius-button`, `--color-accent`, etc.)
- Respects `prefers-reduced-motion` via the existing media query in `global.css`

## Visual behavior

| State | Before | After |
|-------|--------|-------|
| Resting | Green accent text, default underline | Standard text color, thin underline |
| Hover | Text turns darker green | Underline expands to full accent fill, text inverts to bg color |