### PR TITLE
feat: add International Speaker and What I Talk About sections to homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,6 +52,9 @@ export default defineConfig({
           "download",
           "chart-bar",
           "monitor",
+          "robot-outline",
+          "code-braces",
+          "trending-up",
         ],
         teenyicons: [
           "youtube-outline",

--- a/src/components/HomeSpeakingShowcase.astro
+++ b/src/components/HomeSpeakingShowcase.astro
@@ -1,0 +1,321 @@
+---
+import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
+import Section from "./Section.astro";
+import Button, { ButtonType } from "./Button.astro";
+import CarouselNavButton from "./CarouselNavButton.astro";
+import speakingHeroShiftStage from "../images/speaking/info-bip-shift-23/speaking-hero-stage-1.png";
+import speakingHeroWisconsin from "../images/speaking/that-conf-wisconsin-23/speaking-image-hero.jpg";
+import speakingHeroRenderAtl from "../images/speaking/render-23/speaking-hero-renderatl.png";
+import speakingHeroAllThingsOpen from "../images/speaking/all-things-open-23/speaking-stage.jpg";
+import speakingHeroAuditoriumBw from "../images/speaking/gallery-auditorium-bw.png";
+
+const images: { src: ImageMetadata; alt: string; event: string; location: string }[] = [
+  {
+    src: speakingHeroShiftStage,
+    alt: "James Q Quick speaking on stage with dramatic spotlights and audience in the background.",
+    event: "InfoBip Shift",
+    location: "Zadar, Croatia",
+  },
+  {
+    src: speakingHeroWisconsin,
+    alt: "James Q Quick speaking on stage in front of a conference audience.",
+    event: "THAT Conference",
+    location: "Wisconsin Dells, WI",
+  },
+  {
+    src: speakingHeroRenderAtl,
+    alt: "James Q Quick presenting on stage at Render ATL.",
+    event: "Render ATL",
+    location: "Atlanta, GA",
+  },
+  {
+    src: speakingHeroAllThingsOpen,
+    alt: "James Q Quick speaking on stage at All Things Open.",
+    event: "All Things Open",
+    location: "Raleigh, NC",
+  },
+  {
+    src: speakingHeroAuditoriumBw,
+    alt: "Black and white photo of James Q Quick speaking from the stage in a large auditorium.",
+    event: "Conference Keynote",
+    location: "Live Event",
+  },
+];
+
+const first = images[0];
+const n = images.length;
+
+function stackFor(index: number, selected: number) {
+  if (n === 0) return "hidden";
+  const rel = (index - selected + n) % n;
+  if (rel === 0) return "0";
+  if (rel === 1) return "1";
+  if (rel === 2) return "2";
+  return "hidden";
+}
+---
+
+<Section paddingY="spacious" id="speaking">
+  <div class="grid gap-12 items-center lg:grid-cols-2 max-w-6xl mx-auto">
+
+    <!-- Left: text + stat pills + CTAs -->
+    <div>
+      <p class="ds-kicker text-accent mb-5">International Speaker</p>
+      <h2 class="text-3xl md:text-5xl font-bold leading-tight mb-6">
+        From the US to Croatia, I keynote conferences around the world.
+      </h2>
+      <p class="text-base md:text-lg text-textMuted leading-relaxed mb-4">
+        I speak on AI for developers, developer experience, and career growth at
+        conferences internationally. Whether it's a 500-person keynote or an
+        intimate workshop, I bring energy, practical insights, and real stories
+        from the trenches.
+      </p>
+      <div class="flex flex-wrap items-center gap-3 text-sm text-textMuted mb-8">
+        <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1">
+          <span class="h-2 w-2 rounded-full bg-accent"></span>
+          50+ conference talks
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1">
+          <span class="h-2 w-2 rounded-full bg-accent"></span>
+          4+ countries
+        </span>
+        <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1">
+          <span class="h-2 w-2 rounded-full bg-accent"></span>
+          10+ years experience
+        </span>
+      </div>
+      <div class="flex flex-wrap gap-4">
+        <Button
+          text="Invite me to speak"
+          href="/speaking#speakerForm"
+          isLink
+          type={ButtonType.PRIMARY}
+        />
+        <Button
+          text="See my talks"
+          href="/speaking"
+          isLink
+          type={ButtonType.SECONDARY}
+        />
+      </div>
+    </div>
+
+    <!-- Right: stacked card carousel -->
+    <div
+      class="group home-speaking-carousel mx-auto w-full max-w-none md:max-w-[400px] lg:max-w-[460px]"
+      data-home-speaking-carousel
+      tabindex="0"
+      role="region"
+      aria-roledescription="carousel"
+      aria-label="Speaking photos"
+    >
+      <div class="relative pr-6 pt-1 sm:pr-8 sm:pt-0 md:pr-10">
+        <div class="relative">
+          <div
+            class="home-deck-viewport relative mx-auto aspect-[3/4] w-full overflow-visible"
+            aria-hidden="false"
+          >
+            <div class="home-deck-stack pointer-events-none absolute inset-0">
+              {
+                images.map((img, idx) => (
+                  <div
+                    class="home-deck-card absolute left-0 top-0 h-full w-full will-change-transform"
+                    id={`home-speaking-slide-${idx}`}
+                    data-home-card
+                    data-index={idx}
+                    data-stack={stackFor(idx, 0)}
+                    role="group"
+                    aria-roledescription="slide"
+                    aria-label={`${idx + 1} of ${images.length}: ${img.alt}`}
+                    data-event={img.event}
+                    data-location={img.location}
+                  >
+                    <div class="home-deck-card-inner h-full w-full overflow-hidden rounded-[var(--radius-hero)] border border-border bg-surface shadow-xl shadow-black/30">
+                      <Image
+                        class="h-full w-full object-cover"
+                        src={img.src}
+                        alt={img.alt}
+                        format="webp"
+                        quality={82}
+                        widths={[360, 480, 720, 960]}
+                        sizes="(min-width: 1024px) 460px, (min-width: 768px) 400px, 100vw"
+                        loading={idx === 0 ? "eager" : "lazy"}
+                      />
+                    </div>
+                  </div>
+                ))
+              }
+            </div>
+          </div>
+          <CarouselNavButton
+            direction="prev"
+            size="sm"
+            ariaLabel="Previous speaking photo"
+            class="left-2 z-40"
+          />
+          <CarouselNavButton
+            direction="next"
+            size="sm"
+            ariaLabel="Next speaking photo"
+            class="right-2 z-40"
+          />
+        </div>
+      </div>
+
+      <!-- Event / location label below the deck -->
+      <div class="mt-7 w-full" aria-live="polite">
+        <div class="mx-auto flex w-full justify-center md:max-w-[92%] lg:max-w-[88%]">
+          <div class="home-carousel-meta inline-grid w-full max-w-full grid-cols-[2.75rem_minmax(0,1fr)] gap-x-3 text-left md:max-w-[19rem] sm:gap-x-4 lg:max-w-[20rem]">
+            <div class="flex flex-shrink-0 flex-col items-center pt-1" aria-hidden="true">
+              <span class="home-pin-dot h-3 w-3 flex-shrink-0 rounded-full bg-accent shadow-[0_0_14px_3px_rgba(43,241,181,0.45)] ring-2 ring-accent/30" />
+              <span class="mt-0.5 h-[22px] w-px flex-shrink-0 bg-gradient-to-b from-accent via-accent/70 to-accent/15 sm:h-6" />
+            </div>
+            <div class="flex min-h-[5rem] min-w-0 flex-col justify-start sm:min-h-[5.25rem]">
+              <p
+                data-home-carousel-event
+                class="text-[0.9375rem] font-medium uppercase leading-snug tracking-[0.08em] text-text sm:text-lg sm:tracking-[0.06em]"
+              >
+                {first?.event ?? ""}
+              </p>
+              <p
+                data-home-carousel-location
+                class="mt-1 min-h-[1.25em] text-sm leading-snug text-textMuted sm:text-[0.9375rem]"
+              >
+                {first?.location ?? ""}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</Section>
+
+<style>
+  .home-deck-card {
+    transform-origin: center center;
+    transition:
+      transform 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+      opacity 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+      filter 0.45s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  }
+
+  .home-deck-card[data-stack="0"] {
+    transform: translate3d(0, 0, 0) scale(1);
+    opacity: 1;
+    filter: brightness(1);
+    z-index: 30;
+    pointer-events: auto;
+  }
+
+  .home-deck-card[data-stack="1"] {
+    transform: translate3d(1.35rem, 0, 0) scale(0.93);
+    opacity: 0.82;
+    filter: brightness(0.52);
+    z-index: 20;
+  }
+
+  .home-deck-card[data-stack="2"] {
+    transform: translate3d(2.65rem, 0, 0) scale(0.86);
+    opacity: 0.68;
+    filter: brightness(0.42);
+    z-index: 10;
+  }
+
+  .home-deck-card[data-stack="hidden"] {
+    transform: translate3d(3.6rem, 0, 0) scale(0.8);
+    opacity: 0;
+    filter: brightness(0.35);
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  @media (min-width: 640px) {
+    .home-deck-card[data-stack="1"] { transform: translate3d(1.65rem, 0, 0) scale(0.935); }
+    .home-deck-card[data-stack="2"] { transform: translate3d(3.15rem, 0, 0) scale(0.87); }
+    .home-deck-card[data-stack="hidden"] { transform: translate3d(4.25rem, 0, 0) scale(0.82); }
+  }
+
+  @media (min-width: 768px) {
+    .home-deck-card[data-stack="1"] { transform: translate3d(1.85rem, 0, 0) scale(0.94); }
+    .home-deck-card[data-stack="2"] { transform: translate3d(3.55rem, 0, 0) scale(0.88); }
+    .home-deck-card[data-stack="hidden"] { transform: translate3d(4.85rem, 0, 0) scale(0.83); }
+  }
+
+  @media (min-width: 1024px) {
+    .home-deck-card[data-stack="1"] { transform: translate3d(2.05rem, 0, 0) scale(0.945); }
+    .home-deck-card[data-stack="2"] { transform: translate3d(3.95rem, 0, 0) scale(0.89); }
+    .home-deck-card[data-stack="hidden"] { transform: translate3d(5.35rem, 0, 0) scale(0.84); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .home-deck-card { transition-duration: 0.01ms; }
+  }
+</style>
+
+<script>
+  const roots = document.querySelectorAll("[data-home-speaking-carousel]");
+
+  roots.forEach((root) => {
+    const cards = root.querySelectorAll<HTMLElement>("[data-home-card]");
+    const count = cards.length;
+    if (count === 0) return;
+
+    const eventEl = root.querySelector("[data-home-carousel-event]");
+    const locationEl = root.querySelector("[data-home-carousel-location]");
+    const prevBtn = root.querySelector(".carousel-nav-prev");
+    const nextBtn = root.querySelector(".carousel-nav-next");
+
+    let selected = 0;
+
+    const stackKey = (index: number, sel: number) => {
+      const rel = (index - sel + count) % count;
+      if (rel === 0) return "0";
+      if (rel === 1) return "1";
+      if (rel === 2) return "2";
+      return "hidden";
+    };
+
+    const syncMeta = () => {
+      const card = cards[selected];
+      if (!card) return;
+      const { event: ev, location: loc } = card.dataset;
+      if (eventEl) eventEl.textContent = ev ?? "";
+      if (locationEl) locationEl.textContent = loc ?? "";
+      root.setAttribute("aria-activedescendant", card.id || "");
+    };
+
+    const applyStack = () => {
+      cards.forEach((card, j) => {
+        card.setAttribute("data-stack", stackKey(j, selected));
+      });
+      syncMeta();
+    };
+
+    applyStack();
+
+    const go = (delta: number) => {
+      selected = (selected + delta + count) % count;
+      applyStack();
+    };
+
+    prevBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      go(-1);
+    });
+    nextBtn?.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      go(1);
+    });
+
+    root.addEventListener("keydown", (e) => {
+      if (!(e instanceof KeyboardEvent)) return;
+      if (e.key === "ArrowLeft") { e.preventDefault(); go(-1); }
+      if (e.key === "ArrowRight") { e.preventDefault(); go(1); }
+    });
+  });
+</script>

--- a/src/components/HomeSpeakingShowcase.astro
+++ b/src/components/HomeSpeakingShowcase.astro
@@ -8,7 +8,6 @@ import speakingHeroShiftStage from "../images/speaking/info-bip-shift-23/speakin
 import speakingHeroWisconsin from "../images/speaking/that-conf-wisconsin-23/speaking-image-hero.jpg";
 import speakingHeroRenderAtl from "../images/speaking/render-23/speaking-hero-renderatl.png";
 import speakingHeroAllThingsOpen from "../images/speaking/all-things-open-23/speaking-stage.jpg";
-import speakingHeroAuditoriumBw from "../images/speaking/gallery-auditorium-bw.png";
 
 const images: { src: ImageMetadata; alt: string; event: string; location: string }[] = [
   {
@@ -34,12 +33,6 @@ const images: { src: ImageMetadata; alt: string; event: string; location: string
     alt: "James Q Quick speaking on stage at All Things Open.",
     event: "All Things Open",
     location: "Raleigh, NC",
-  },
-  {
-    src: speakingHeroAuditoriumBw,
-    alt: "Black and white photo of James Q Quick speaking from the stage in a large auditorium.",
-    event: "Conference Keynote",
-    location: "Live Event",
   },
 ];
 

--- a/src/components/HomeSpeakingShowcase.astro
+++ b/src/components/HomeSpeakingShowcase.astro
@@ -92,12 +92,6 @@ function stackFor(index: number, selected: number) {
           isLink
           type={ButtonType.PRIMARY}
         />
-        <Button
-          text="See my talks"
-          href="/speaking"
-          isLink
-          type={ButtonType.SECONDARY}
-        />
       </div>
     </div>
 

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -29,7 +29,7 @@ const topics = [
     <div class="mx-auto mb-12 max-w-3xl text-center">
       <p class="ds-kicker text-accent mb-3">What I talk about</p>
       <h2 class="text-3xl font-bold md:text-5xl mb-4">
-        Sessions that move developers forward
+        Helping builders build.
       </h2>
       <p class="text-base leading-relaxed text-textMuted md:text-lg">
         Every talk is built to give your audience something they can use the next day: a new AI workflow, a DX strategy, or the confidence to take the next step in their career.

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -12,13 +12,13 @@ const topics = [
   {
     title: "Developer Experience",
     description:
-      "What makes developers productive, happy, and effective. From tooling and DX strategy to building products developers love, drawn from years leading DX at Auth0, PlanetScale, and Cloudflare.",
+      "What makes developers productive, happy, and effective. From tooling and DX strategy to building products developers love, drawn from years focusing on DX at Auth0, PlanetScale, and Cloudflare.",
     icon: "mdi:code-braces",
   },
   {
     title: "Career Growth",
     description:
-      "Navigating career transitions, building your brand, and finding your voice. From Microsoft to startups to full-time creator and back to industry. I talk openly about all of it.",
+      "Navigating career transitions, building your brand, and finding your voice. From Microsoft to startups to full-time creator and back. I talk openly about all of it.",
     icon: "mdi:trending-up",
   },
 ];

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -6,19 +6,19 @@ const topics = [
   {
     title: "AI for Developers",
     description:
-      "Practical AI workflows, agents, and shipping with AI tools — not just demoing them. How AI changes what developers build and how they build it.",
+      "Practical AI workflows, agents, and shipping with AI tools. Not just demoing them. How AI changes what developers build and how they build it.",
     icon: "mdi:robot-outline",
   },
   {
     title: "Developer Experience",
     description:
-      "What makes developers productive, happy, and effective. From tooling and DX strategy to building products developers love — drawn from years leading DX at Auth0, PlanetScale, and Cloudflare.",
+      "What makes developers productive, happy, and effective. From tooling and DX strategy to building products developers love, drawn from years leading DX at Auth0, PlanetScale, and Cloudflare.",
     icon: "mdi:code-braces",
   },
   {
     title: "Career Growth",
     description:
-      "Navigating career transitions, building your brand, and finding your voice. From Microsoft to startups to full-time creator and back to industry — I talk openly about all of it.",
+      "Navigating career transitions, building your brand, and finding your voice. From Microsoft to startups to full-time creator and back to industry. I talk openly about all of it.",
     icon: "mdi:trending-up",
   },
 ];
@@ -32,7 +32,7 @@ const topics = [
         Sessions that move developers forward
       </h2>
       <p class="text-base leading-relaxed text-textMuted md:text-lg">
-        Every talk is built to give your audience something they can use the next day — whether that's a new AI workflow, a DX strategy, or the confidence to take the next step in their career.
+        Every talk is built to give your audience something they can use the next day: a new AI workflow, a DX strategy, or the confidence to take the next step in their career.
       </p>
     </div>
     <div class="grid gap-8 md:grid-cols-3">

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -1,0 +1,58 @@
+---
+import Section from "./Section.astro";
+import { Icon } from "astro-icon/components";
+
+const topics = [
+  {
+    title: "AI for Developers",
+    description:
+      "Practical AI workflows, agents, and shipping with AI tools — not just demoing them. How AI changes what developers build and how they build it.",
+    icon: "mdi:robot-outline",
+  },
+  {
+    title: "Developer Experience",
+    description:
+      "What makes developers productive, happy, and effective. From tooling and DX strategy to building products developers love — drawn from years leading DX at Auth0, PlanetScale, and Cloudflare.",
+    icon: "mdi:code-braces",
+  },
+  {
+    title: "Career Growth",
+    description:
+      "Navigating career transitions, building your brand, and finding your voice. From Microsoft to startups to full-time creator and back to industry — I talk openly about all of it.",
+    icon: "mdi:trending-up",
+  },
+];
+---
+
+<Section tone="elevated" paddingY="spacious">
+  <div class="max-w-6xl mx-auto">
+    <div class="mx-auto mb-12 max-w-3xl text-center">
+      <p class="ds-kicker text-accent mb-3">What I talk about</p>
+      <h2 class="text-3xl font-bold md:text-5xl mb-4">
+        Sessions that move developers forward
+      </h2>
+      <p class="text-base leading-relaxed text-textMuted md:text-lg">
+        Every talk is built to give your audience something they can use the next day — whether that's a new AI workflow, a DX strategy, or the confidence to take the next step in their career.
+      </p>
+    </div>
+    <div class="grid gap-8 md:grid-cols-3">
+      {
+        topics.map((topic) => (
+          <div class="bg-surface rounded-xl p-6 md:p-8 border border-border">
+            <div class="mb-5 flex h-14 w-14 items-center justify-center rounded-full border border-border bg-bg">
+              <Icon
+                name={topic.icon}
+                class="h-7 w-7 text-accent"
+                aria-hidden="true"
+              />
+            </div>
+            <h3 class="mb-3 text-xl font-bold text-text">{topic.title}</h3>
+            <p class="text-sm leading-relaxed text-textMuted md:text-base">
+              {topic.description}
+            </p>
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</Section>

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -24,7 +24,7 @@ const topics = [
 ];
 ---
 
-<Section tone="elevated" paddingY="spacious">
+<Section tone="base" paddingY="spacious">
   <div class="max-w-6xl mx-auto">
     <div class="mx-auto mb-12 max-w-3xl text-center">
       <p class="ds-kicker text-accent mb-3">What I talk about</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -58,7 +58,6 @@ export const prerender = true;
   </AboutCallout> -->
   <HomeSpeakingShowcase />
   <HomeTopics />
-  <CoursesCallout />
   <WorkExperience />
 
   <!-- <SpeakingCallout /> -->

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,6 +7,8 @@ import BlogCallout from "../components/BlogCallout.astro";
 import AboutCallout from "../components/AboutCallout.astro";
 import SpeakingCallout from "../components/SpeakingCallout.astro";
 import CoursesCallout from "../components/CoursesCallout.astro";
+import HomeSpeakingShowcase from "../components/HomeSpeakingShowcase.astro";
+import HomeTopics from "../components/HomeTopics.astro";
 import Button, { ButtonType } from "../components/Button.astro";
 import Link from "../components/Link.astro";
 import selfie from "../images/selfie.png";
@@ -54,6 +56,8 @@ export const prerender = true;
       />
     </div>
   </AboutCallout> -->
+  <HomeSpeakingShowcase />
+  <HomeTopics />
   <CoursesCallout />
   <WorkExperience />
 


### PR DESCRIPTION
## Summary

Adds two focused sections to the homepage, branched cleanly from `main`.

### HomeSpeakingShowcase
- Eyebrow: "International Speaker"
- Heading: "From the US to Croatia, I keynote conferences around the world."
- Body copy on AI / DX / career growth speaking
- Stat pills: 50+ conference talks · 4+ countries · 10+ years experience
- Stacked card photo carousel — same deck interaction as the speaking page (arrow left/right, animated stack, event + location label beneath)
- CTAs: "Invite me to speak" → `/speaking#speakerForm` and "See my talks" → `/speaking`

### HomeTopics
- Eyebrow: "What I talk about"
- Heading: "Sessions that move developers forward"
- Three cards: AI for Developers · Developer Experience · Career Growth
- Icons: `mdi:robot-outline`, `mdi:code-braces`, `mdi:trending-up`

### astro.config.mjs
- Registers `robot-outline`, `code-braces`, `trending-up` in the `astro-icon` include list (required — unbundled icons crash SSR silently and produce an empty page body)

## Notes
- Carousel uses `data-home-speaking-carousel` / `data-home-card` attributes so it does not conflict with the speaking page carousel script
- Sections are inserted after `SocialCallout` and before `CoursesCallout`, leaving the rest of the homepage unchanged
