### PR TITLE
Impeccable design pass: home speaking + social sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist
 .astro
 worktrees/
 src/data/blog/**/.DS_Store
+.impeccable/live/sessions/

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,132 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-05-29T00:00:00.000Z",
+  "title": "Design System: James Q Quick",
+  "extensions": {
+    "colorMeta": {
+      "signal-green": { "role": "primary", "displayName": "Signal Green", "canonical": "#0AFA94", "tonalRamp": ["#06301e", "#074a2e", "#08643d", "#09a463", "#0AFA94", "#4dfbb1", "#86fccc", "#bdfde2", "#e6fff4"] },
+      "stage-navy": { "role": "neutral", "displayName": "Stage Navy", "canonical": "#0b1020", "tonalRamp": ["#070a16", "#0b1020", "#111830", "#17203a", "#1a2342", "#25314d", "#3a496f", "#5a6886", "#94a3b8"] },
+      "surface": { "role": "neutral", "displayName": "Surface", "canonical": "#111830", "tonalRamp": ["#0b1020", "#111830", "#17203a", "#1a2342", "#25314d", "#36406a", "#4c5888", "#7a86ad", "#c2cbd8"] },
+      "ink": { "role": "neutral", "displayName": "Ink", "canonical": "#f8fafc", "tonalRamp": ["#25314d", "#475569", "#64748b", "#94a3b8", "#c2cbd8", "#dde3ec", "#eef2f7", "#f8fafc", "#ffffff"] },
+      "cat-speaking": { "role": "secondary", "displayName": "Speaking Pink", "canonical": "#ff6b8a", "tonalRamp": ["#3a0d1a", "#5e1429", "#8a1d3c", "#c42b58", "#ff6b8a", "#ff8da4", "#ffb0bf", "#ffd2da", "#fff0f3"] },
+      "cat-ai": { "role": "secondary", "displayName": "AI Cyan", "canonical": "#35cfff", "tonalRamp": ["#06303d", "#094a5e", "#0c6480", "#1399c4", "#35cfff", "#6bdcff", "#9ae8ff", "#c5f2ff", "#e9fbff"] }
+    },
+    "typographyMeta": {
+      "display": { "displayName": "Display", "purpose": "Hero headlines in Space Grotesk. The loudest voice." },
+      "headline": { "displayName": "Headline", "purpose": "Section titles in Space Grotesk." },
+      "body": { "displayName": "Body", "purpose": "Inter 300, muted ink, capped 65-75ch." },
+      "label": { "displayName": "Kicker", "purpose": "Uppercase IBM Plex Mono eyebrow. Developer-brand signature." }
+    },
+    "shadows": [
+      { "name": "shadow-sm", "value": "0 1px 2px rgba(2,8,20,0.24), 0 0 0 1px rgba(148,163,184,0.08)", "purpose": "Subtle resting lift on small surfaces." },
+      { "name": "shadow-card", "value": "0 8px 20px rgba(2,8,20,0.26), 0 0 0 1px rgba(148,163,184,0.1)", "purpose": "Default for cards and raised content." },
+      { "name": "shadow-lg", "value": "0 14px 34px rgba(2,8,20,0.34), 0 0 0 1px rgba(148,163,184,0.14)", "purpose": "Button hover lift and elevated overlays only." },
+      { "name": "shadow-focus", "value": "0 0 0 3px rgba(10,250,148,0.28)", "purpose": "Green focus glow on interactive elements." }
+    ],
+    "motion": [
+      { "name": "ease-out", "value": "cubic-bezier(0.22, 1, 0.36, 1)", "purpose": "Default easing for state transitions." },
+      { "name": "ease-emphasized", "value": "cubic-bezier(0.2, 0.8, 0.2, 1)", "purpose": "Emphasized entrances." },
+      { "name": "duration-fast", "value": "140ms", "purpose": "Color/border hovers." },
+      { "name": "duration-normal", "value": "200ms", "purpose": "Transform and shadow transitions." }
+    ],
+    "breakpoints": [
+      { "name": "md", "value": "768px" },
+      { "name": "lg", "value": "1024px" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Primary Button",
+      "kind": "button",
+      "refersTo": "button-primary",
+      "description": "Filled signal-green CTA. The speaking CTA and key actions.",
+      "html": "<button class=\"ds-btn-primary\">Invite me to speak</button>",
+      "css": ".ds-btn-primary { display: inline-flex; align-items: center; justify-content: center; gap: 1rem; background: var(--color-accent, #0AFA94); color: var(--color-text-on-accent, #0b1020); border: 1px solid transparent; border-radius: var(--radius-button, 12px); padding: 0.875rem 1.5rem; font-family: var(--font-sans, Inter, sans-serif); font-weight: 600; font-size: 1.125rem; line-height: 1.75rem; cursor: pointer; transition: background-color 140ms cubic-bezier(0.22,1,0.36,1), box-shadow 200ms cubic-bezier(0.22,1,0.36,1), transform 200ms cubic-bezier(0.22,1,0.36,1); } .ds-btn-primary:hover { background: var(--color-accent-hover, #04cd78); transform: translateY(-2px); box-shadow: 0 14px 34px rgba(2,8,20,0.34); } .ds-btn-primary:active { transform: translateY(0); } .ds-btn-primary:focus-visible { outline: 2px solid var(--color-accent, #0AFA94); outline-offset: 2px; box-shadow: 0 0 0 3px rgba(10,250,148,0.28); }"
+    },
+    {
+      "name": "Secondary Button",
+      "kind": "button",
+      "refersTo": "button-secondary",
+      "description": "Outlined button; border and text shift to green on hover.",
+      "html": "<button class=\"ds-btn-secondary\">See the talks</button>",
+      "css": ".ds-btn-secondary { display: inline-flex; align-items: center; justify-content: center; gap: 1rem; background: transparent; color: var(--color-text, #f8fafc); border: 1px solid var(--color-border, #25314d); border-radius: var(--radius-button, 12px); padding: 0.875rem 1.5rem; font-family: var(--font-sans, Inter, sans-serif); font-weight: 600; font-size: 1.125rem; line-height: 1.75rem; cursor: pointer; transition: color 140ms cubic-bezier(0.22,1,0.36,1), border-color 140ms cubic-bezier(0.22,1,0.36,1), background-color 140ms cubic-bezier(0.22,1,0.36,1), transform 200ms cubic-bezier(0.22,1,0.36,1); } .ds-btn-secondary:hover { border-color: var(--color-accent, #0AFA94); color: var(--color-accent, #0AFA94); background: rgba(10,250,148,0.18); transform: translateY(-2px); } .ds-btn-secondary:focus-visible { outline: 2px solid var(--color-accent, #0AFA94); outline-offset: 2px; box-shadow: 0 0 0 3px rgba(10,250,148,0.28); }"
+    },
+    {
+      "name": "Fancy Link",
+      "kind": "custom",
+      "refersTo": "link-fancy",
+      "description": "Signature link: a 1px ink underline expands into a full rounded green fill on hover while text flips to navy.",
+      "html": "<a class=\"ds-link-fancy\" href=\"#\"><span class=\"ds-link-fancy-text\">read the post</span><span class=\"ds-link-fancy-bg\" aria-hidden=\"true\"></span></a>",
+      "css": ".ds-link-fancy { position: relative; display: inline-block; padding-inline: 0.35em; padding-block: 0.2em; color: var(--color-text, #f8fafc); line-height: 1.45; text-decoration: none; cursor: pointer; } .ds-link-fancy-text { position: relative; z-index: 1; } .ds-link-fancy-bg { position: absolute; z-index: 0; left: 0; right: 0; bottom: 0.12em; height: 1px; border-radius: var(--radius-button, 12px); background: var(--color-text, #f8fafc); pointer-events: none; transition: left 200ms cubic-bezier(0.22,1,0.36,1), right 200ms cubic-bezier(0.22,1,0.36,1), bottom 200ms cubic-bezier(0.22,1,0.36,1), height 200ms cubic-bezier(0.22,1,0.36,1), background-color 200ms cubic-bezier(0.22,1,0.36,1); } .ds-link-fancy:hover, .ds-link-fancy:hover .ds-link-fancy-text { color: var(--color-bg, #0b1020); } .ds-link-fancy:hover .ds-link-fancy-bg { left: -0.125rem; right: -0.125rem; bottom: 0; height: 100%; background: var(--color-accent, #0AFA94); }"
+    },
+    {
+      "name": "Kicker",
+      "kind": "custom",
+      "refersTo": "label",
+      "description": "Uppercase monospace eyebrow above section headings. Developer-brand signature.",
+      "html": "<p class=\"ds-kicker\">Speaking</p>",
+      "css": ".ds-kicker { font-family: var(--font-mono, 'IBM Plex Mono', monospace); text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.9375rem; line-height: 1.375rem; font-weight: 400; color: var(--color-accent, #0AFA94); margin: 0; }"
+    },
+    {
+      "name": "Card",
+      "kind": "card",
+      "refersTo": "card",
+      "description": "Raised content surface; lifts one tonal step on hover.",
+      "html": "<div class=\"ds-card\"><p class=\"ds-card-title\">Talk title</p><p class=\"ds-card-body\">A short description of the talk and where it was delivered.</p></div>",
+      "css": ".ds-card { background: var(--color-surface, #111830); color: var(--color-text, #f8fafc); border-radius: var(--radius-card, 16px); padding: 24px; box-shadow: 0 8px 20px rgba(2,8,20,0.26), 0 0 0 1px rgba(148,163,184,0.1); transition: background-color 140ms cubic-bezier(0.22,1,0.36,1), transform 200ms cubic-bezier(0.22,1,0.36,1); } .ds-card:hover { background: var(--color-surface-hover, #17203a); transform: translateY(-2px); } .ds-card-title { font-family: var(--font-display, 'Space Grotesk', sans-serif); font-weight: 600; font-size: 1.25rem; margin: 0 0 0.5rem; } .ds-card-body { font-family: var(--font-sans, Inter, sans-serif); font-weight: 300; color: var(--color-text-muted, #c2cbd8); margin: 0; }"
+    },
+    {
+      "name": "Search Input",
+      "kind": "input",
+      "refersTo": "input",
+      "description": "Text field with green focus glow.",
+      "html": "<input class=\"ds-input\" type=\"text\" placeholder=\"Search posts\" />",
+      "css": ".ds-input { background: var(--color-surface, #111830); color: var(--color-text, #f8fafc); border: 1px solid var(--color-border, #25314d); border-radius: var(--radius-input, 10px); padding: 0.75rem 1rem; font-family: var(--font-sans, Inter, sans-serif); font-size: 1rem; width: 100%; box-sizing: border-box; transition: border-color 140ms cubic-bezier(0.22,1,0.36,1), box-shadow 140ms cubic-bezier(0.22,1,0.36,1); } .ds-input::placeholder { color: var(--color-text-subtle, #94a3b8); } .ds-input:focus-visible { outline: none; border-color: var(--color-accent, #0AFA94); box-shadow: 0 0 0 3px rgba(10,250,148,0.28); }"
+    },
+    {
+      "name": "Theme Toggle",
+      "kind": "button",
+      "refersTo": "button-tertiary",
+      "description": "Icon button in the navbar for dark/light theme.",
+      "html": "<button class=\"ds-theme-toggle\" aria-label=\"toggle theme\"><svg width=\"24\" height=\"24\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><circle cx=\"12\" cy=\"12\" r=\"4\"/><path d=\"M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4\"/></svg></button>",
+      "css": ".ds-theme-toggle { display: inline-flex; align-items: center; justify-content: center; color: var(--color-text, #f8fafc); background: transparent; border: 1px solid var(--color-border, #25314d); border-radius: var(--radius-button, 12px); padding: 0.5rem; cursor: pointer; transition: color 140ms cubic-bezier(0.22,1,0.36,1), border-color 140ms cubic-bezier(0.22,1,0.36,1), background-color 140ms cubic-bezier(0.22,1,0.36,1); } .ds-theme-toggle:hover { color: var(--color-accent, #0AFA94); border-color: var(--color-accent, #0AFA94); background: rgba(10,250,148,0.18); } .ds-theme-toggle:focus-visible { outline: 2px solid var(--color-accent, #0AFA94); outline-offset: 2px; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Keynote Studio",
+    "overview": "This is the lit set where a developer-creator records, writes, and takes the stage. The room is dark on purpose: a deep navy stage that makes one electric signal-green spotlight do the talking. The voice is approachable, energetic, and credible. Warmth and clarity come from generous type and breathing room; authority comes from restraint, never from shouting. Energy is concentrated into a single accent and a confident display face, not sprayed across the screen. The system explicitly rejects the bare-Astro-blog default, neon overload and gimmickry, sterile corporate SaaS templates, and a smug or negative tone. Every surface should read as unmistakably James: a teacher who respects the audience.",
+    "keyCharacteristics": [
+      "Dark-first stage (deep navy #0b1020) with a single high-energy accent.",
+      "One signal-green spotlight (#0AFA94) used sparingly for action and emphasis.",
+      "Display type with personality (Space Grotesk) over quiet, readable body (Inter).",
+      "Monospace kickers as a developer-brand signature.",
+      "Soft, rounded surfaces (12-20px) with subtle depth, never heavy."
+    ],
+    "rules": [
+      { "name": "The Single Spotlight Rule", "body": "Signal green is emphasis, not decoration. On any given screen it carries roughly one job: the primary action or the single thing that must be seen. If two greens compete, one is wrong.", "section": "colors" },
+      { "name": "The Tinted Neutral Rule", "body": "Never #000 or #fff. Every neutral is tinted toward the navy hue. The dark theme is navy, not black; light text is #f8fafc, not pure white.", "section": "colors" },
+      { "name": "The Mono Kicker Rule", "body": "Eyebrows and section labels are uppercase IBM Plex Mono with wide tracking. This is the developer-brand signature; don't replace it with a sans label.", "section": "typography" },
+      { "name": "The Light Body Rule", "body": "Body copy is Inter weight 300 in muted ink, not full-strength ink. Reserve full ink for headings and emphasis.", "section": "typography" },
+      { "name": "The Reserved Shadow Rule", "body": "Keep shadows subtle by default. If a component feels too heavy, reduce opacity or blur before touching color contrast. Heavy, high-contrast shadows belong to overlays only.", "section": "elevation" }
+    ],
+    "dos": [
+      "Do make the speaking CTA the most prominent action on any page it appears, using the primary green button.",
+      "Do keep signal green to roughly one job per screen (The Single Spotlight Rule).",
+      "Do use IBM Plex Mono uppercase kickers above sections for the developer-brand signature.",
+      "Do set body copy in Inter 300 at muted ink, capped at 65-75ch.",
+      "Do build vertical rhythm by alternating Section base and elevated tones with paddingY presets.",
+      "Do give every interactive element a visible green :focus-visible ring; never rely on color alone for meaning.",
+      "Do keep both dark (default) and light themes readable, and respect prefers-reduced-motion."
+    ],
+    "donts": [
+      "Don't ship the bare-Astro / Bear-blog text-only look. This is a designed hub, not an unstyled feed.",
+      "Don't let the brand read as loud, neon-overloaded, or gimmicky. The green is a spotlight, not the room.",
+      "Don't adopt a smug, negative, or disrespectful tone in copy. Respect for the audience is non-negotiable.",
+      "Don't drift into sterile corporate / generic SaaS template territory.",
+      "Don't use #000 or #fff; tint every neutral toward the navy hue.",
+      "Don't nest cards or stack heavy shadows; reserve large shadows for overlays only.",
+      "Don't use a border-left/border-right colored stripe as an accent; use full borders, tints, or the green focus treatment instead.",
+      "Don't repurpose YouTube red or category hues (pink, cyan) as general accents."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["src/layouts/BaseLayout.astro", "src/layouts/BaseLayoutWithProse.astro"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,215 @@
+---
+name: James Q Quick
+description: The personal site of James Q Quick, developer, speaker, and teacher.
+colors:
+  signal-green: "#0AFA94"
+  signal-green-hover: "#04cd78"
+  text-on-accent: "#0b1020"
+  ink: "#f8fafc"
+  ink-muted: "#c2cbd8"
+  ink-subtle: "#94a3b8"
+  stage-navy: "#0b1020"
+  surface: "#111830"
+  surface-hover: "#17203a"
+  section-elevated: "#1a2342"
+  border: "#25314d"
+  cat-speaking: "#ff6b8a"
+  cat-ai: "#35cfff"
+  cat-learning: "#0AFA94"
+  youtube-red: "#eb3223"
+typography:
+  display:
+    fontFamily: "Space Grotesk Variable, Space Grotesk, Inter, sans-serif"
+    fontSize: "clamp(2.5rem, 6vw, 4.5rem)"
+    fontWeight: 600
+    lineHeight: 1.05
+    letterSpacing: "-0.01em"
+  headline:
+    fontFamily: "Space Grotesk Variable, Space Grotesk, sans-serif"
+    fontSize: "clamp(1.75rem, 3.5vw, 2.5rem)"
+    fontWeight: 600
+    lineHeight: 1.15
+  body:
+    fontFamily: "Inter Variable, Inter, sans-serif"
+    fontSize: "1.125rem"
+    fontWeight: 300
+    lineHeight: 1.7
+    letterSpacing: "0.01em"
+  label:
+    fontFamily: "IBM Plex Mono, SF Mono, monospace"
+    fontSize: "0.9375rem"
+    fontWeight: 400
+    lineHeight: 1.375
+    letterSpacing: "0.08em"
+rounded:
+  input: "10px"
+  button: "12px"
+  card: "16px"
+  hero: "20px"
+  full: "9999px"
+spacing:
+  xs: "8px"
+  sm: "12px"
+  md: "16px"
+  lg: "24px"
+  xl: "32px"
+  "2xl": "48px"
+  "3xl": "64px"
+components:
+  button-primary:
+    backgroundColor: "{colors.signal-green}"
+    textColor: "{colors.text-on-accent}"
+    rounded: "{rounded.button}"
+    padding: "0.875rem 1.5rem"
+  button-primary-hover:
+    backgroundColor: "{colors.signal-green-hover}"
+    textColor: "{colors.text-on-accent}"
+  button-secondary:
+    backgroundColor: "{colors.stage-navy}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.button}"
+    padding: "0.875rem 1.5rem"
+  button-secondary-hover:
+    textColor: "{colors.signal-green}"
+  button-tertiary:
+    backgroundColor: "{colors.stage-navy}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.button}"
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.card}"
+    padding: "24px"
+  input:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.ink}"
+    rounded: "{rounded.input}"
+    padding: "0.75rem 1rem"
+---
+
+# Design System: James Q Quick
+
+## 1. Overview
+
+**Creative North Star: "The Keynote Studio"**
+
+This is the lit set where a developer-creator records, writes, and takes the stage. The room is dark on purpose: a deep navy stage that makes one electric signal-green spotlight do the talking. The voice is approachable, energetic, and credible, the same three words that drive the brand. Warmth and clarity come from generous type and breathing room; authority comes from restraint, never from shouting. Energy is concentrated into a single accent and a confident display face, not sprayed across the screen.
+
+The system explicitly rejects the bare-Astro-blog default: this is not an unstyled feed of posts, it is a designed hub. It rejects neon overload and gimmickry: the green is a spotlight, not the whole room. It rejects sterile corporate SaaS templates and the smug, negative tone of some creator sites. Every surface should read as unmistakably James: a teacher who respects the audience.
+
+**Key Characteristics:**
+- Dark-first stage (deep navy `#0b1020`) with a single high-energy accent.
+- One signal-green spotlight (`#0AFA94`) used sparingly for action and emphasis.
+- Display type with personality (Space Grotesk) over quiet, readable body (Inter).
+- Monospace kickers as a developer-brand signature.
+- Soft, rounded surfaces (12-20px) with subtle depth, never heavy.
+
+## 2. Colors
+
+A dark navy stage carrying one electric green accent, with a small set of category hues reserved for content taxonomy. Full dark and light themes both ship; values below are the canonical dark defaults.
+
+### Primary
+- **Signal Green** (`#0AFA94`): The spotlight. Primary CTAs, key emphasis, focus rings, link hover fills, and the "learning" content category. The most important color on the site and the visual anchor of the speaking CTA. Hover deepens to **Signal Green Deep** (`#04cd78`). On light theme it shifts to a legible deep green (`#0a7b4b`).
+- **Text On Accent** (`#0b1020`): Near-navy text used on filled green surfaces so the accent stays high-contrast and readable.
+
+### Secondary (content categories)
+- **Speaking Pink** (`#ff6b8a`): Tags and accents for speaking/talks content.
+- **AI Cyan** (`#35cfff`): Tags and accents for AI-related content.
+
+### Tertiary
+- **YouTube Red** (`#eb3223`): Reserved strictly for YouTube affordances. Never a general accent.
+
+### Neutral
+- **Stage Navy** (`#0b1020`): The page background. The dark room the spotlight needs.
+- **Surface** (`#111830`) / **Surface Hover** (`#17203a`): Cards and raised surfaces; hover lifts one tonal step.
+- **Section Elevated** (`#1a2342`): Alternating section backgrounds for vertical rhythm.
+- **Border** (`#25314d`): Hairline dividers and resting button outlines.
+- **Ink** (`#f8fafc`) / **Ink Muted** (`#c2cbd8`) / **Ink Subtle** (`#94a3b8`): Primary, secondary, and tertiary text.
+
+### Named Rules
+**The Single Spotlight Rule.** Signal green is emphasis, not decoration. On any given screen it carries roughly one job: the primary action or the single thing that must be seen. If two greens compete, one is wrong.
+
+**The Tinted Neutral Rule.** Never `#000` or `#fff`. Every neutral is tinted toward the navy hue. The dark theme is navy, not black; light text is `#f8fafc`, not pure white.
+
+## 3. Typography
+
+**Display Font:** Space Grotesk Variable (with Inter, system-sans fallback)
+**Body Font:** Inter Variable (with system-sans fallback)
+**Label/Mono Font:** IBM Plex Mono (with SF Mono, monospace fallback)
+
+**Character:** Space Grotesk brings geometric, slightly quirky personality to headlines, the confident stage voice. Inter keeps body copy calm, neutral, and highly readable. IBM Plex Mono signals "developer" in kickers and eyebrows, the technical fingerprint of the brand.
+
+### Hierarchy
+- **Display** (600, `clamp(2.5rem, 6vw, 4.5rem)`, line-height 1.05): Hero headlines. Space Grotesk, tight tracking. The site's loudest voice.
+- **Headline** (600, `clamp(1.75rem, 3.5vw, 2.5rem)`, line-height 1.15): Section titles. Space Grotesk.
+- **Title** (600, ~1.5rem): Card and sub-section headings.
+- **Body** (300, 1.125rem, line-height 1.7): Paragraph copy in Inter, light weight, slightly loose tracking. Cap measure at 65-75ch.
+- **Label / Kicker** (400, 0.9375rem, letter-spacing 0.08em, uppercase): IBM Plex Mono eyebrow above sections (`.ds-kicker`).
+
+### Named Rules
+**The Mono Kicker Rule.** Eyebrows and section labels are uppercase IBM Plex Mono with wide tracking. This is the developer-brand signature; don't replace it with a sans label.
+
+**The Light Body Rule.** Body copy is Inter weight 300 in `--color-text-muted`, not full-strength ink. Reserve full ink for headings and emphasis.
+
+## 4. Elevation
+
+Depth is quiet and tonal. Surfaces lift through a step in background tone plus a soft, low-opacity shadow paired with a hairline ring; they do not float on heavy drop shadows. Shadow strength is reserved: small and card shadows for resting surfaces, large shadows only for genuinely elevated overlays (modals, popups). Shadows are decomposed into depth-only and ring-only tokens so a surface can take a ring without a drop, or vice versa.
+
+### Shadow Vocabulary
+- **Small** (`--shadow-sm`: `0 1px 2px rgba(2,8,20,0.24)` + hairline ring): Subtle resting lift on small surfaces.
+- **Card** (`--shadow-card`: `0 8px 20px rgba(2,8,20,0.26)` + ring): Default for cards and raised content.
+- **Large** (`--shadow-lg`: `0 14px 34px rgba(2,8,20,0.34)` + ring): Button hover lift and elevated overlays only.
+- **Focus** (`--shadow-focus`: `0 0 0 3px rgba(10,250,148,0.28)`): The green focus glow on interactive elements.
+
+### Named Rules
+**The Reserved Shadow Rule.** Keep shadows subtle by default. If a component feels too heavy, reduce opacity or blur before touching color contrast. Heavy, high-contrast shadows belong to overlays only.
+
+## 5. Components
+
+### Buttons
+- **Shape:** Softly rounded (12px, `--radius-button`). Inline-flex, centered, 1rem gap for icon + label.
+- **Primary:** Filled signal green (`#0AFA94`) with near-navy text (`#0b1020`). Padding `0.875rem 1.5rem` at desktop. The speaking CTA and key actions.
+- **Secondary:** Transparent with a `--color-border` outline and ink text. Hover shifts border and text to green over a faint green-subtle wash.
+- **Tertiary:** Borderless, ink text, green on hover. For low-emphasis actions.
+- **Hover / Focus:** All buttons lift 2px on hover with a large shadow; active returns to 0. Focus-visible draws a 2px green outline (offset 2px) plus the green focus glow.
+
+### Links
+- **Fancy link (default):** Inline-block with a 1px baseline underline in ink that, on hover, expands into a full rounded signal-green fill while text flips to navy. The signature interactive flourish; mirrored for prose links via `.ds-prose a`.
+- **Simple link:** Inherits color, turns green on hover.
+
+### Cards / Containers
+- **Corner Style:** 16px (`--radius-card`).
+- **Background:** `--color-surface` (`#111830`), lifting to `--color-surface-hover` on interaction.
+- **Shadow Strategy:** `--shadow-card` at rest (see Elevation). Never stack heavy shadows on nested elements; nested cards are forbidden.
+- **Internal Padding:** 24px baseline, on the approved rhythm.
+
+### Inputs / Fields
+- **Style:** `--color-surface` background, `--color-border` stroke, 10px radius (`--radius-input`).
+- **Focus:** 2px green outline plus the green focus glow. Never rely on color alone.
+
+### Navigation
+- **Style:** Transparent 100px-tall bar, logo left, text links right (About, Blog, Speaking, Courses, Uses) plus a theme toggle. Links are ink, turning green on hover. Mobile collapses to a full-screen `--color-bg` overlay menu.
+
+### Section
+- **Behavior:** A `Section` primitive owns vertical rhythm via `paddingY` presets (`half` / `default` / `spacious` / `xl`) and a `tone` (`base` / `elevated`). Alternate `base` and `elevated` tones to build rhythm; never hand-roll `py-*` or `bg-*` on sections.
+
+## 6. Do's and Don'ts
+
+### Do:
+- **Do** make the speaking CTA the most prominent action on any page it appears, using the primary green button.
+- **Do** keep signal green to roughly one job per screen (The Single Spotlight Rule).
+- **Do** use IBM Plex Mono uppercase kickers above sections for the developer-brand signature.
+- **Do** set body copy in Inter 300 at `--color-text-muted`, capped at 65-75ch.
+- **Do** build vertical rhythm by alternating `Section` `base` and `elevated` tones with `paddingY` presets.
+- **Do** give every interactive element a visible green `:focus-visible` ring; never rely on color alone for meaning.
+- **Do** keep both dark (default) and light themes readable, and respect `prefers-reduced-motion`.
+
+### Don't:
+- **Don't** ship the bare-Astro / Bear-blog text-only look. This is a designed hub, not an unstyled feed.
+- **Don't** let the brand read as loud, neon-overloaded, or gimmicky. The green is a spotlight, not the room.
+- **Don't** adopt a smug, negative, or disrespectful tone in copy. Respect for the audience is non-negotiable.
+- **Don't** drift into sterile corporate / generic SaaS template territory.
+- **Don't** use `#000` or `#fff`; tint every neutral toward the navy hue.
+- **Don't** nest cards or stack heavy shadows; reserve large shadows for overlays only.
+- **Don't** use a `border-left`/`border-right` colored stripe as an accent; use full borders, tints, or the green focus treatment instead.
+- **Don't** repurpose YouTube red or category hues (pink, cyan) as general accents.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,44 @@
+# Product
+
+## Register
+
+brand
+
+## Users
+
+**Primary: developers leveling up.** Beginner-to-intermediate developers who arrive from YouTube, conference talks, or search, watch and read to learn, and over time come to trust James as a go-to teacher. They want practical, clear, encouraging guidance, not gatekeeping.
+
+**Secondary: event organizers and conferences.** People evaluating James as a speaker. They need fast proof that he speaks on a topic and has real, deep content behind it, then an obvious way to invite him.
+
+**Tertiary: sponsors and collaborators.** Brands and partners assessing credibility, reach, and professionalism before working together.
+
+## Product Purpose
+
+This is James Q Quick's personal site, the home base for his work as a content creator, speaker, and teacher. It exists to build credibility and awareness for what he does and to prove, through linkable content, that he is an authoritative voice on the things he talks about.
+
+The most important conversion right now is the **speaking CTA**: turning an interested organizer into an "ask me to speak" inquiry. Content (blog posts, talks, courses, cheat sheets) is the evidence that backs that authority and the engine that keeps developers coming back. Success looks like: organizers reach out to book talks, developers repeatedly return to learn, and any specific piece of content can be surfaced and routed to on demand.
+
+## Brand Personality
+
+**Approachable, energetic, credible.** Friendly-teacher warmth with genuine expert authority. The voice is encouraging and human, never condescending, cynical, or negative. Energetic and creator-forward, but the energy comes from enthusiasm and clarity, not hype or gimmicks. James is respected for how he uses content to grow an audience; the site should feel like the polished, trustworthy hub that reputation earns.
+
+## Anti-references
+
+- **Not a boring, text-only default blog.** The Bear-blog / bare-Astro-starter look is the failure state. It should feel alive and designed, not like an unstyled feed of posts.
+- **Not negative, smug, or disrespectful in tone.** Admire how creators like Theo grew via content, but explicitly reject the negatively-opinionated, disrespectful posture. Respect for the audience is non-negotiable.
+- **Not loud, neon-overloaded, or gimmicky.** The bright accent is a tool, not the whole room.
+- **Not sterile corporate / generic SaaS template.** Identity should be unmistakably James, not a stock theme.
+
+Reference lane (the right feel): personality-forward dev-creator and speaker/keynote sites with strong, polished identity, e.g. Wes Bos, Josh Comeau, Jason Lengstorf, Matt Pocock.
+
+## Design Principles
+
+1. **Prove it with content.** Every claim of expertise is backed by linkable receipts (talks, posts, courses). Authority is shown, not asserted.
+2. **Make "invite me to speak" the headline action.** The speaking CTA is the clearest, most reachable next step across the site.
+3. **Approachable expert, never condescending.** Warmth and clarity sit alongside credibility. Teach generously; respect the reader.
+4. **Energy without hype.** Lively and creator-forward, but grounded. Enthusiasm over gimmicks.
+5. **Content is the engine.** Surface the right blog post, course, or cheat sheet and route people to it; the site is a hub, not a dead end.
+
+## Accessibility & Inclusion
+
+Target WCAG 2.1 AA. Carry forward the existing design-system baseline: visible `:focus-visible` styles on every interactive element, never rely on color alone for meaning, respect `prefers-reduced-motion`, and maintain readable contrast in both the dark (default) and light themes.

--- a/src/components/Button.astro
+++ b/src/components/Button.astro
@@ -94,6 +94,7 @@ const classes = `button-base ${variantClasses[type]} ${hasOutline ? "button--out
     border-color: transparent;
     color: var(--color-text-on-accent);
     text-decoration: none;
+    box-shadow: 0 8px 26px rgba(10, 250, 148, 0.35);
   }
 
   .button--primary:hover,
@@ -101,6 +102,7 @@ const classes = `button-base ${variantClasses[type]} ${hasOutline ? "button--out
     background: var(--color-accent-hover);
     color: var(--color-text-on-accent);
     text-decoration: none;
+    box-shadow: 0 12px 40px rgba(10, 250, 148, 0.5);
   }
 
   .button--secondary,

--- a/src/components/HomeSpeakingShowcase.astro
+++ b/src/components/HomeSpeakingShowcase.astro
@@ -58,11 +58,12 @@ function stackFor(index: number, selected: number) {
       <h2 class="text-3xl md:text-5xl font-bold leading-tight mb-6">
         From the US to Croatia, I keynote conferences around the world.
       </h2>
-      <p class="text-base md:text-lg text-textMuted leading-relaxed mb-4">
-        I speak on AI for developers, developer experience, and career growth at
-        conferences internationally. Whether it's a 500-person keynote or an
-        intimate workshop, I bring energy, practical insights, and real stories
-        from the trenches.
+      <p class="text-base md:text-lg text-textMuted leading-relaxed text-pretty max-w-[60ch] mb-4">
+        I speak on <strong class="font-semibold text-text">AI for developers</strong>, <strong
+          class="font-semibold text-text">developer experience</strong
+        >, and <strong class="font-semibold text-text">career growth</strong> at conferences
+        internationally. Whether it's a 500-person keynote or an intimate workshop, I bring
+        energy, practical insights, and real stories from the trenches.
       </p>
       <div class="flex flex-wrap items-center gap-3 text-sm text-textMuted mb-8">
         <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1">
@@ -79,12 +80,22 @@ function stackFor(index: number, selected: number) {
         </span>
       </div>
       <div class="flex flex-wrap gap-4">
-        <Button
-          text="Invite me to speak"
-          href="/speaking#speakerForm"
-          isLink
-          type={ButtonType.PRIMARY}
-        />
+        <Button href="/speaking#speakerForm" isLink type={ButtonType.PRIMARY}>
+          Invite me to speak
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14M13 6l6 6-6 6"></path>
+          </svg>
+        </Button>
       </div>
     </div>
 

--- a/src/components/SocialCallout.astro
+++ b/src/components/SocialCallout.astro
@@ -1,15 +1,21 @@
 ---
 import Section from "./Section.astro";
-import SocialFollow from "./SocialFollow.astro";
+import SocialFollow, { IconSize } from "./SocialFollow.astro";
 ---
 
 <Section tone="elevated" paddingY="half">
-  <div class="flex flex-col md:flex-row justify-center gap-x-4 items-center">
-    <div class="text-center mb-6 md:mb-0">
-      <p class="text-xl mb-1 text-text">@jamesqquick</p>
-      <p class="text-xl text-textMuted">250k+ followers</p>
+  <div class="flex flex-col items-center text-center gap-7">
+    <div>
+      <p class="ds-kicker text-accent mb-1">@jamesqquick</p>
+      <p
+        class="font-display font-bold tracking-[-0.02em] leading-[0.92] text-text text-[clamp(2.75rem,9vw,4.75rem)]"
+      >
+        250K+
+      </p>
+      <p class="font-mono uppercase tracking-[0.12em] text-[0.8125rem] text-textMuted mt-1.5">
+        followers
+      </p>
     </div>
-    <div class="hidden md:block h-12 w-[1px] bg-border"></div>
-    <SocialFollow />
+    <SocialFollow size={IconSize.Small} />
   </div>
 </Section>


### PR DESCRIPTION
## Summary

A focused design pass on the homepage, generated and accepted via the impeccable `live` workflow. All changes stay on brand (dark navy stage, signal-green spotlight, Space Grotesk display, IBM Plex Mono kickers).

### UI changes
- **Button** (`src/components/Button.astro`): the `primary` variant now carries a signal-green glow (resting `0 8px 26px rgba(10,250,148,.35)`, hover `0 12px 40px rgba(10,250,148,.5)`). Applied at the component level, so **every `ButtonType.PRIMARY` shares it**.
- **Speaking intro** (`src/components/HomeSpeakingShowcase.astro`): the three speaking topics ("AI for developers", "developer experience", "career growth") are emphasized in full-ink semibold with balanced wrapping; the "Invite me to speak" CTA gains a trailing arrow via the Button slot.
- **Social proof** (`src/components/SocialCallout.astro`): recomposed to lead with a large Space Grotesk "250K+" number, a green mono `@jamesqquick` kicker, a "followers" label, and smaller social icons (`SocialFollow size={IconSize.Small}`).

### Context / tooling
- `PRODUCT.md` and `DESIGN.md`: strategic + visual system docs for the impeccable workflow.
- `.impeccable/design.json`, `.impeccable/live/config.json`: live-mode tooling config.
- `.gitignore`: ignore live-mode session journals.

### Notes
- `WorkExperience.astro` was explored but reverted; no change here.
- Watch the "Single Spotlight" rule: if two primary buttons ever share a viewport, both will glow. Easy to scope to a hero modifier later if needed.

🤖 Generated with [opencode](https://opencode.ai)