### PR TITLE
feat: add privacy policy page

### DIFF
--- a/src/pages/privacy-policy.mdx
+++ b/src/pages/privacy-policy.mdx
@@ -6,56 +6,13 @@ description: Privacy Policy for James Q Quick
 
 export const prerender = true;
 
-_Last updated: June 22, 2026_
-
-This Privacy Policy describes how James Q Quick ("we," "us," or "our") collects, uses, and shares information about you when you visit this website or interact with us.
-
-## Information We Collect
-
-We may collect information you provide directly to us, such as your name and email address when you subscribe to our newsletter or contact us. We may also automatically collect certain information when you visit our site, including your IP address, browser type, referring URLs, and pages visited.
-
-## How We Use Your Information
-
-We use the information we collect to:
-
-- Send newsletters and other communications you have opted into
-- Respond to your questions and requests
-- Improve and maintain the website
-- Analyze usage trends
-
 ## Mobile Communications
 
 **No mobile information will be sold or shared with third parties for promotional or marketing purposes.**
 
 If you provide a phone number or opt into any mobile messaging program, that information is used solely to fulfill the specific communications you requested. We do not share mobile opt-in data with any third party for their own marketing purposes.
 
-## Email Communications
-
-If you subscribe to our newsletter, you can unsubscribe at any time by clicking the unsubscribe link in any email we send. We do not sell or rent your email address to third parties.
-
-## Third-Party Services
-
-We may use third-party analytics services (such as Google Analytics) to understand how visitors interact with our site. These services may collect information about your visits across websites. You can opt out of analytics tracking by using browser extensions or visiting the opt-out pages provided by those services.
-
-## Cookies
-
-This site may use cookies and similar tracking technologies to improve your experience. You can control cookie settings through your browser preferences.
-
-## Data Security
-
-We take reasonable measures to protect your information from unauthorized access or disclosure. However, no transmission over the internet is completely secure, and we cannot guarantee the absolute security of your data.
-
-## Children's Privacy
-
-This site is not directed at children under the age of 13. We do not knowingly collect personal information from children.
-
-## Changes to This Policy
-
-We may update this Privacy Policy from time to time. When we do, we will update the "Last updated" date at the top of this page.
-
 ## Contact
-
-If you have any questions about this Privacy Policy, you can reach us at:
 
 <address>
 James Q Quick<br />

--- a/src/pages/privacy-policy.mdx
+++ b/src/pages/privacy-policy.mdx
@@ -1,0 +1,64 @@
+---
+layout: "../layouts/ProseLayout.astro"
+title: Privacy Policy
+description: Privacy Policy for James Q Quick
+---
+
+export const prerender = true;
+
+_Last updated: June 22, 2026_
+
+This Privacy Policy describes how James Q Quick ("we," "us," or "our") collects, uses, and shares information about you when you visit this website or interact with us.
+
+## Information We Collect
+
+We may collect information you provide directly to us, such as your name and email address when you subscribe to our newsletter or contact us. We may also automatically collect certain information when you visit our site, including your IP address, browser type, referring URLs, and pages visited.
+
+## How We Use Your Information
+
+We use the information we collect to:
+
+- Send newsletters and other communications you have opted into
+- Respond to your questions and requests
+- Improve and maintain the website
+- Analyze usage trends
+
+## Mobile Communications
+
+**No mobile information will be sold or shared with third parties for promotional or marketing purposes.**
+
+If you provide a phone number or opt into any mobile messaging program, that information is used solely to fulfill the specific communications you requested. We do not share mobile opt-in data with any third party for their own marketing purposes.
+
+## Email Communications
+
+If you subscribe to our newsletter, you can unsubscribe at any time by clicking the unsubscribe link in any email we send. We do not sell or rent your email address to third parties.
+
+## Third-Party Services
+
+We may use third-party analytics services (such as Google Analytics) to understand how visitors interact with our site. These services may collect information about your visits across websites. You can opt out of analytics tracking by using browser extensions or visiting the opt-out pages provided by those services.
+
+## Cookies
+
+This site may use cookies and similar tracking technologies to improve your experience. You can control cookie settings through your browser preferences.
+
+## Data Security
+
+We take reasonable measures to protect your information from unauthorized access or disclosure. However, no transmission over the internet is completely secure, and we cannot guarantee the absolute security of your data.
+
+## Children's Privacy
+
+This site is not directed at children under the age of 13. We do not knowingly collect personal information from children.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. When we do, we will update the "Last updated" date at the top of this page.
+
+## Contact
+
+If you have any questions about this Privacy Policy, you can reach us at:
+
+<address>
+James Q Quick<br />
+8518 Hunters Horn<br />
+Germantown, TN 38138
+</address>


### PR DESCRIPTION
Adds a `/privacy-policy` page with:

- Required mobile data statement: *"No mobile information will be sold or shared with third parties for promotional or marketing purposes."*
- Full privacy policy covering data collection, email communications, cookies, third-party services, and data security
- Mailing address (8518 Hunters Horn, Germantown, TN 38138) in the Contact section
- Uses `ProseLayout` and `export const prerender = true` to match existing page conventions