### PR TITLE
refactor(styles): kebab-case Tailwind color keys and drop v3-only aliases

### DIFF
--- a/src/components/CarouselNavButton.astro
+++ b/src/components/CarouselNavButton.astro
@@ -28,7 +28,7 @@ const navClass =
   type="button"
   class:list={[
     navClass,
-    "pointer-events-auto absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-full border border-accent/70 bg-accent text-[var(--color-text-on-accent)] shadow-lg shadow-black/35 transition-all hover:scale-105 hover:bg-accentHover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
+    "pointer-events-auto absolute top-1/2 flex -translate-y-1/2 items-center justify-center rounded-full border border-accent/70 bg-accent text-[var(--color-text-on-accent)] shadow-lg shadow-black/35 transition-all hover:scale-105 hover:bg-accent-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent",
     sizeClass,
     className,
   ]}

--- a/src/components/HomeSpeakingShowcase.astro
+++ b/src/components/HomeSpeakingShowcase.astro
@@ -58,14 +58,14 @@ function stackFor(index: number, selected: number) {
       <h2 class="text-3xl md:text-5xl font-bold leading-tight mb-6">
         From the US to Croatia, I keynote conferences around the world.
       </h2>
-      <p class="text-base md:text-lg text-textMuted leading-relaxed text-pretty max-w-[60ch] mb-4">
+      <p class="text-base md:text-lg text-text-muted leading-relaxed text-pretty max-w-[60ch] mb-4">
         I speak on <strong class="font-semibold text-text">AI for developers</strong>, <strong
           class="font-semibold text-text">developer experience</strong
         >, and <strong class="font-semibold text-text">career growth</strong> at conferences
         internationally. Whether it's a 500-person keynote or an intimate workshop, I bring
         energy, practical insights, and real stories from the trenches.
       </p>
-      <div class="flex flex-wrap items-center gap-3 text-sm text-textMuted mb-8">
+      <div class="flex flex-wrap items-center gap-3 text-sm text-text-muted mb-8">
         <span class="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1">
           <span class="h-2 w-2 rounded-full bg-accent"></span>
           50+ conference talks
@@ -165,9 +165,9 @@ function stackFor(index: number, selected: number) {
       <div class="mt-7 w-full" aria-live="polite">
         <div class="mx-auto flex w-full justify-center md:max-w-[92%] lg:max-w-[88%]">
           <div class="home-carousel-meta inline-grid w-full max-w-full grid-cols-[2.75rem_minmax(0,1fr)] gap-x-3 text-left md:max-w-[19rem] sm:gap-x-4 lg:max-w-[20rem]">
-            <div class="flex flex-shrink-0 flex-col items-center pt-1" aria-hidden="true">
-              <span class="home-pin-dot h-3 w-3 flex-shrink-0 rounded-full bg-accent shadow-[0_0_14px_3px_rgba(43,241,181,0.45)] ring-2 ring-accent/30" />
-              <span class="mt-0.5 h-[22px] w-px flex-shrink-0 bg-gradient-to-b from-accent via-accent/70 to-accent/15 sm:h-6" />
+            <div class="flex shrink-0 flex-col items-center pt-1" aria-hidden="true">
+              <span class="home-pin-dot h-3 w-3 shrink-0 rounded-full bg-accent shadow-[0_0_14px_3px_rgba(43,241,181,0.45)] ring-2 ring-accent/30" />
+              <span class="mt-0.5 h-[22px] w-px shrink-0 bg-gradient-to-b from-accent via-accent/70 to-accent/15 sm:h-6" />
             </div>
             <div class="flex min-h-[5rem] min-w-0 flex-col justify-start sm:min-h-[5.25rem]">
               <p
@@ -178,7 +178,7 @@ function stackFor(index: number, selected: number) {
               </p>
               <p
                 data-home-carousel-location
-                class="mt-1 min-h-[1.25em] text-sm leading-snug text-textMuted sm:text-[0.9375rem]"
+                class="mt-1 min-h-[1.25em] text-sm leading-snug text-text-muted sm:text-[0.9375rem]"
               >
                 {first?.location ?? ""}
               </p>

--- a/src/components/HomeTopics.astro
+++ b/src/components/HomeTopics.astro
@@ -31,7 +31,7 @@ const topics = [
       <h2 class="text-3xl font-bold md:text-5xl mb-4">
         Helping builders build.
       </h2>
-      <p class="text-base leading-relaxed text-textMuted md:text-lg">
+      <p class="text-base leading-relaxed text-text-muted md:text-lg">
         Every talk is built to give your audience something they can use the next day: a new AI workflow, a DX strategy, or the confidence to take the next step in their career.
       </p>
     </div>
@@ -47,7 +47,7 @@ const topics = [
               />
             </div>
             <h3 class="mb-3 text-xl font-bold text-text">{topic.title}</h3>
-            <p class="text-sm leading-relaxed text-textMuted md:text-base">
+            <p class="text-sm leading-relaxed text-text-muted md:text-base">
               {topic.description}
             </p>
           </div>

--- a/src/components/NewsletterForm.svelte
+++ b/src/components/NewsletterForm.svelte
@@ -56,7 +56,7 @@
       />
       <button
         disabled={loading}
-        class="text-xl rounded-full px-4 py-4 sm:py-2 bg-accent text-[var(--color-text-on-accent)] hover:bg-accentHover hover:scale-105 transition-all inline-block sm:absolute right-4 top-[50%] -translate-y-[50%] mt-6 sm:mt-0"
+        class="text-xl rounded-full px-4 py-4 sm:py-2 bg-accent text-[var(--color-text-on-accent)] hover:bg-accent-hover hover:scale-105 transition-all inline-block sm:absolute right-4 top-[50%] -translate-y-[50%] mt-6 sm:mt-0"
       >
         {loading ? "Subscribing..." : "Sign Me Up!"}
       </button>

--- a/src/components/RecentTalks.astro
+++ b/src/components/RecentTalks.astro
@@ -12,7 +12,7 @@ const talks = await getFeaturedTalks();
     {
       talks.map((talk) => (
         <div class="flex lg:flex-row flex-col gap-4 items-start :items-center">
-          <div class="rounded-full border h-20 w-20 border-border border-opacity-50 flex items-center justify-center">
+          <div class="rounded-full border h-20 w-20 border-border flex items-center justify-center">
             <Image
               class="rounded-full w-14 h-14 object-contain"
               src={talk.data.conferenceLogo}

--- a/src/components/SocialCallout.astro
+++ b/src/components/SocialCallout.astro
@@ -12,7 +12,7 @@ import SocialFollow, { IconSize } from "./SocialFollow.astro";
       >
         250K+
       </p>
-      <p class="font-mono uppercase tracking-[0.12em] text-[0.8125rem] text-textMuted mt-1.5">
+      <p class="font-mono uppercase tracking-[0.12em] text-[0.8125rem] text-text-muted mt-1.5">
         followers
       </p>
     </div>

--- a/src/components/SpeakerFormCallout.astro
+++ b/src/components/SpeakerFormCallout.astro
@@ -17,7 +17,7 @@ const { kitLinks = [] } = Astro.props as Props;
     <div class="speaker-card border border-border bg-surface text-text shadow-sm p-8">
       <p class="ds-kicker text-accent mb-3">Let's work together</p>
       <h2 class="text-4xl font-bold mb-4">Bring me to your event</h2>
-      <p class="text-textMuted mb-8">
+      <p class="text-text-muted mb-8">
         Please first read through my <Link
           text="Speaker Rider"
           isFancy={true}

--- a/src/components/course-content/Sidebar.astro
+++ b/src/components/course-content/Sidebar.astro
@@ -29,7 +29,7 @@ const completedSet = new Set(completedLessons);
       );
       return (
         <section>
-          <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-textMuted font-sans">
+          <h3 class="mb-2 text-xs font-semibold uppercase tracking-wider text-text-muted font-sans">
             {section.title}
           </h3>
           <ul class="space-y-1">
@@ -46,7 +46,7 @@ const completedSet = new Set(completedLessons);
                       "flex items-center gap-2 border-l-2 px-3 py-2 text-sm rounded-r-md transition-colors font-sans",
                       isCurrent
                         ? "border-accent bg-accent/10 text-accent font-medium"
-                        : "border-transparent text-textMuted hover:bg-surface-hover hover:text-text",
+                        : "border-transparent text-text-muted hover:bg-surface-hover hover:text-text",
                     ]}
                   >
                     <span

--- a/src/components/speaking/SpeakerForm.svelte
+++ b/src/components/speaking/SpeakerForm.svelte
@@ -92,7 +92,7 @@
   >
     Send Request
   </button>
-  <p class="text-lg text-center text-textMuted" transition:fade>
+  <p class="text-lg text-center text-text-muted" transition:fade>
     {#if successMsg}
       {successMsg}
     {:else if errorMsg}

--- a/src/components/speaking/SpeakingAbout.astro
+++ b/src/components/speaking/SpeakingAbout.astro
@@ -26,7 +26,7 @@ const {
     <div>
       <p class="ds-kicker text-accent mb-3">{eyebrow}</p>
       <h2 class="text-3xl md:text-5xl font-bold mb-5 max-w-xl text-text">{heading}</h2>
-      <p class="text-lg text-textMuted max-w-2xl leading-relaxed">{description}</p>
+      <p class="text-lg text-text-muted max-w-2xl leading-relaxed">{description}</p>
       <div class="mt-7">
         <Link href={readMoreCta.href} text={readMoreCta.label} classStr="font-semibold text-text" />
       </div>

--- a/src/components/speaking/SpeakingFeaturedTalk.astro
+++ b/src/components/speaking/SpeakingFeaturedTalk.astro
@@ -33,7 +33,7 @@ const count = talks.length;
   <div class="max-w-6xl mx-auto px-8">
     <div class="text-center mb-10 md:mb-12">
       <h2 class="text-3xl md:text-5xl font-bold mb-4 text-text">{heading}</h2>
-      <p class="text-textMuted text-base md:text-lg max-w-2xl mx-auto leading-relaxed">
+      <p class="text-text-muted text-base md:text-lg max-w-2xl mx-auto leading-relaxed">
         {subtext}
       </p>
     </div>
@@ -140,7 +140,7 @@ const count = talks.length;
                   data-tick-bar
                   class:list={[
                     "w-px rounded-full transition-all duration-500 ease-out",
-                    idx === 0 ? "h-9 md:h-10 bg-text" : "h-3 md:h-4 bg-textMuted",
+                    idx === 0 ? "h-9 md:h-10 bg-text" : "h-3 md:h-4 bg-text-muted",
                   ]}
                 />
               </button>

--- a/src/components/speaking/SpeakingHero.astro
+++ b/src/components/speaking/SpeakingHero.astro
@@ -43,7 +43,7 @@ function stackFor(index: number, selected: number) {
       <h1 class="text-4xl md:text-6xl font-bold leading-tight mb-6 max-w-xl">{title}</h1>
       {
         description ? (
-          <p class="text-lg text-textMuted max-w-xl">{description}</p>
+          <p class="text-lg text-text-muted max-w-xl">{description}</p>
         ) : null
       }
       <div class="mt-8 flex flex-wrap items-center gap-6">
@@ -130,11 +130,11 @@ function stackFor(index: number, selected: number) {
       <div class="mt-7 w-full" aria-live="polite">
         <div class="mx-auto flex w-full justify-center md:max-w-[92%] lg:max-w-[88%]">
           <div class="hero-carousel-meta inline-grid w-full max-w-full grid-cols-[2.75rem_minmax(0,1fr)] gap-x-3 text-left md:max-w-[19rem] sm:gap-x-4 lg:max-w-[20rem]">
-            <div class="flex flex-shrink-0 flex-col items-center pt-1" aria-hidden="true">
+            <div class="flex shrink-0 flex-col items-center pt-1" aria-hidden="true">
               <span
-                class="hero-pin-dot h-3 w-3 flex-shrink-0 rounded-full bg-accent shadow-[0_0_14px_3px_rgba(43,241,181,0.45)] ring-2 ring-accent/30"
+                class="hero-pin-dot h-3 w-3 shrink-0 rounded-full bg-accent shadow-[0_0_14px_3px_rgba(43,241,181,0.45)] ring-2 ring-accent/30"
               />
-              <span class="mt-0.5 h-[22px] w-px flex-shrink-0 bg-gradient-to-b from-accent via-accent/70 to-accent/15 sm:h-6" />
+              <span class="mt-0.5 h-[22px] w-px shrink-0 bg-gradient-to-b from-accent via-accent/70 to-accent/15 sm:h-6" />
             </div>
             <div class="flex min-h-[5rem] min-w-0 flex-col justify-start sm:min-h-[5.25rem]">
               <p
@@ -145,7 +145,7 @@ function stackFor(index: number, selected: number) {
               </p>
               <p
                 data-carousel-location
-                class="mt-1 min-h-[1.25em] text-sm leading-snug text-textMuted sm:text-[0.9375rem]"
+                class="mt-1 min-h-[1.25em] text-sm leading-snug text-text-muted sm:text-[0.9375rem]"
               >
                 {first?.location ?? ""}
               </p>

--- a/src/components/speaking/SpeakingStats.astro
+++ b/src/components/speaking/SpeakingStats.astro
@@ -19,7 +19,7 @@ const { stats } = Astro.props as Props;
   <div class="relative max-w-6xl mx-auto">
     <div class="mx-auto mb-10 max-w-3xl text-center md:mb-12">
       <h2 class="mb-4 text-3xl font-bold md:text-5xl">What I talk about</h2>
-      <p class="text-base leading-relaxed text-textMuted md:text-lg">
+      <p class="text-base leading-relaxed text-text-muted md:text-lg">
         Sessions designed to help developers grow their careers, sharpen their craft, and build with confidence.
       </p>
     </div>
@@ -59,7 +59,7 @@ const { stats } = Astro.props as Props;
                 <Icon name={item.icon} class="h-8 w-8 text-accent md:h-9 md:w-9" aria-hidden="true" />
               </div>
               <h3 class="mb-3 text-lg font-bold text-text md:text-xl">{item.title}</h3>
-              <p class="max-w-xs text-sm leading-relaxed text-textMuted md:max-w-none md:text-base">
+              <p class="max-w-xs text-sm leading-relaxed text-text-muted md:max-w-none md:text-base">
                 {item.description}
               </p>
             </div>

--- a/src/components/speaking/SpeakingTopics.astro
+++ b/src/components/speaking/SpeakingTopics.astro
@@ -23,7 +23,7 @@ const { topics } = Astro.props as Props;
       topics.map((topic) => (
         <article class="rounded-2xl bg-surface p-7 h-full border border-border shadow-md">
           <h3 class="text-2xl font-semibold mb-3">{topic.title}</h3>
-          <p class="text-textMuted">{topic.description}</p>
+          <p class="text-text-muted">{topic.description}</p>
         </article>
       ))
     }

--- a/src/components/speaking/Testimonial.astro
+++ b/src/components/speaking/Testimonial.astro
@@ -15,7 +15,7 @@ const { Content } = await render(testimonial);
 ---
 
 <div class="bg-surface rounded-xl p-6 md:p-7 border border-border h-full">
-  <div class={`${isShort ? "text-base leading-7" : "tracking-wider text-xl leading-8"} relative text-textMuted mb-8`}>
+  <div class={`${isShort ? "text-base leading-7" : "tracking-wider text-xl leading-8"} relative text-text-muted mb-8`}>
     {!isShort && <Content />}
     {isShort && shortQuote}
   </div>
@@ -32,7 +32,7 @@ const { Content } = await render(testimonial);
     />
     <div>
       <h3 class="text-lg text-accent font-bold">{name}</h3>
-      <h4 class="text-sm font-light text-textMuted">{title}</h4>
+      <h4 class="text-sm font-light text-text-muted">{title}</h4>
     </div>
   </div>
 </div>

--- a/src/pages/course/[...lesson].astro
+++ b/src/pages/course/[...lesson].astro
@@ -78,7 +78,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
       <button
         id="open-sidebar-btn"
         aria-label="Open course navigation"
-        class="inline-flex items-center gap-2 text-sm text-textMuted font-sans"
+        class="inline-flex items-center gap-2 text-sm text-text-muted font-sans"
       >
         <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2">
           <line x1="3" y1="6" x2="21" y2="6"></line>
@@ -92,7 +92,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
     <div id="sidebar-drawer" class="fixed inset-0 z-50 hidden lg:hidden">
       <div id="sidebar-overlay" class="absolute inset-0 bg-black/40"></div>
       <aside class="absolute left-0 top-0 h-full w-80 max-w-[85vw] overflow-y-auto border-r border-border bg-surface p-5">
-        <button id="close-sidebar-btn" aria-label="Close navigation" class="mb-4 text-sm text-textMuted font-sans">
+        <button id="close-sidebar-btn" aria-label="Close navigation" class="mb-4 text-sm text-text-muted font-sans">
           Close
         </button>
         <Sidebar
@@ -157,7 +157,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
             <Content components={mdxComponents} />
           </div>
         <div class="mt-8 rounded-xl border border-border p-4 not-prose">
-          <div class="flex items-center justify-between text-sm text-textMuted font-sans">
+          <div class="flex items-center justify-between text-sm text-text-muted font-sans">
             <p>Lesson {currentIndex + 1} of {lessons.length}</p>
             <p>{Math.round(((currentIndex + 1) / lessons.length) * 100)}%</p>
           </div>
@@ -176,7 +176,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
                   ←
                 </span>
                 <span class="min-w-0">
-                  <span class="block text-xs uppercase tracking-wider text-textMuted">Previous</span>
+                  <span class="block text-xs uppercase tracking-wider text-text-muted">Previous</span>
                   <span class="block truncate text-sm text-text">{prevLesson.data.title}</span>
                 </span>
               </a>
@@ -190,7 +190,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
                 class="flex items-center justify-between gap-3 rounded-xl border border-border px-4 py-3 font-sans no-underline hover:no-underline transition-colors hover:border-accent"
               >
                 <span class="min-w-0 text-right">
-                  <span class="block text-xs uppercase tracking-wider text-textMuted">Next</span>
+                  <span class="block text-xs uppercase tracking-wider text-text-muted">Next</span>
                   <span class="block truncate text-sm text-text">{nextLesson.data.title}</span>
                 </span>
                 <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border text-sm text-text">
@@ -203,7 +203,7 @@ const hasVideo = Boolean(lesson.data.videoKey || lessonVideoUrl);
                 class="flex items-center justify-between gap-3 rounded-xl border border-border px-4 py-3 font-sans no-underline hover:no-underline transition-colors hover:border-accent"
               >
                 <span class="min-w-0 text-right">
-                  <span class="block text-xs uppercase tracking-wider text-textMuted">Finish</span>
+                  <span class="block text-xs uppercase tracking-wider text-text-muted">Finish</span>
                   <span class="block truncate text-sm text-text">Complete Course</span>
                 </span>
                 <span class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full border border-border text-sm text-text">

--- a/src/pages/course/[courseSlug].astro
+++ b/src/pages/course/[courseSlug].astro
@@ -47,7 +47,7 @@ const { Content } = await render(course);
       <button
         id="open-sidebar-btn"
         aria-label="Open course navigation"
-        class="inline-flex items-center gap-2 text-sm text-textMuted font-sans"
+        class="inline-flex items-center gap-2 text-sm text-text-muted font-sans"
       >
         <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2">
           <line x1="3" y1="6" x2="21" y2="6"></line>
@@ -61,7 +61,7 @@ const { Content } = await render(course);
     <div id="sidebar-drawer" class="fixed inset-0 z-50 hidden lg:hidden">
       <div id="sidebar-overlay" class="absolute inset-0 bg-black/40"></div>
       <aside class="absolute left-0 top-0 h-full w-80 max-w-[85vw] overflow-y-auto border-r border-border bg-surface p-5">
-        <button id="close-sidebar-btn" aria-label="Close navigation" class="mb-4 text-sm text-textMuted font-sans">
+        <button id="close-sidebar-btn" aria-label="Close navigation" class="mb-4 text-sm text-text-muted font-sans">
           Close
         </button>
         <Sidebar

--- a/src/pages/course/[courseSlug]/complete.astro
+++ b/src/pages/course/[courseSlug]/complete.astro
@@ -24,13 +24,13 @@ if (!course) {
     <Section classStr="pt-16 pb-24">
       <div class="max-w-2xl mx-auto text-center space-y-6">
         <h1 class="text-4xl font-bold font-display text-text">Course Complete</h1>
-        <p class="text-textMuted">Great work finishing {course.data.title}.</p>
+        <p class="text-text-muted">Great work finishing {course.data.title}.</p>
         <canvas id="fireworks" class="fixed inset-0 pointer-events-none"></canvas>
         <div class="border border-border rounded-xl p-6 bg-surface/80">
-          <p class="text-sm text-textMuted">Certificate</p>
+          <p class="text-sm text-text-muted">Certificate</p>
           <p id="cert-course" class="text-xl font-semibold font-display text-text mt-2">{course.data.title}</p>
-          <p id="cert-date" class="text-sm text-textMuted mt-2"></p>
-          <p id="cert-id" class="text-xs text-textMuted mt-3"></p>
+          <p id="cert-date" class="text-sm text-text-muted mt-2"></p>
+          <p id="cert-id" class="text-xs text-text-muted mt-3"></p>
         </div>
         <div class="flex gap-3 justify-center">
           <a href="/courses">Browse More Courses</a>

--- a/src/pages/work-with-me.astro
+++ b/src/pages/work-with-me.astro
@@ -21,26 +21,26 @@ import BaseLayout from "../layouts/BaseLayout.astro";
   <Section hasYPadding={true}>
     <div class="text-center mb-10">
       <h2 class="text-3xl md:text-5xl font-bold">Services</h2>
-      <p class="text-textMuted mt-3">Choose from one of these options</p>
+      <p class="text-text-muted mt-3">Choose from one of these options</p>
     </div>
     <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
       <article class="bg-surface border border-border rounded-2xl p-8 shadow-md">
         <h3 class="text-2xl font-bold mb-4">Book me to speak</h3>
-        <p class="text-textMuted mb-6">
+        <p class="text-text-muted mb-6">
           From modern web development to career growth and personal development, I deliver sessions that are practical and engaging.
         </p>
         <Button text="Book a speaking engagement" href="/speaking/#speakerForm" isLink type={ButtonType.PRIMARY} />
       </article>
       <article class="bg-surface border border-border rounded-2xl p-8 shadow-md">
         <h3 class="text-2xl font-bold mb-4">Sponsor my content</h3>
-        <p class="text-textMuted mb-6">
+        <p class="text-text-muted mb-6">
           Reach intermediate developers through educational content and creator partnerships grounded in trust and technical depth.
         </p>
         <Button text="Discuss sponsorship" href="/speaking/#speakerForm" isLink type={ButtonType.SECONDARY} />
       </article>
       <article class="bg-surface border border-border rounded-2xl p-8 shadow-md">
         <h3 class="text-2xl font-bold mb-4">Consultation</h3>
-        <p class="text-textMuted mb-6">
+        <p class="text-text-muted mb-6">
           Get focused support on developer experience, content strategy, and technical communication for your team or community.
         </p>
         <Button text="Request consultation" href="/speaking/#speakerForm" isLink type={ButtonType.SECONDARY} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,7 +45,7 @@ p {
   @apply font-sans;
   @apply prose-headings:font-display prose-headings:text-text;
   @apply prose-h2:text-accent prose-h3:text-text prose-h4:text-text;
-  @apply prose-p:text-textMuted prose-li:text-textMuted;
+  @apply prose-p:text-text-muted prose-li:text-text-muted;
   @apply prose-strong:text-text;
   @apply prose-a:text-text prose-a:no-underline;
   @apply prose-code:font-mono prose-pre:font-mono;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -8,10 +8,10 @@ module.exports = {
         youtube: "#eb3223",
         /* Semantic token-based colors */
         accent: "var(--color-accent)",
-        accentHover: "var(--color-accent-hover)",
+        "accent-hover": "var(--color-accent-hover)",
         "accent-subtle": "var(--color-accent-subtle)",
         text: "var(--color-text)",
-        textMuted: "var(--color-text-muted)",
+        "text-muted": "var(--color-text-muted)",
         "text-subtle": "var(--color-text-subtle)",
         bg: "var(--color-bg)",
         surface: "var(--color-surface)",


### PR DESCRIPTION
Prep for the Tailwind v4 migration, split out as a separate **no-op** change so the actual v4 diff stays reviewable. Every change here is valid on Tailwind 3, so this can merge and sit safely on its own.

## Changes

- **Rename `textMuted` -> `text-muted` and `accentHover` -> `accent-hover`** in `tailwind.config.mjs` plus all 40 usages. Tailwind v4 exposes theme keys as CSS custom properties, where camelCase keys fail *silently* rather than erroring — so these would have quietly stopped applying. Every other multi-word key in the config was already kebab-case, so this also makes the config internally consistent.
- **`flex-shrink-0` -> `shrink-0`** (6 usages). v3 emits both names as a single combined selector (`.flex-shrink-0,.shrink-0`), proving they're exact aliases; v4 ships only `shrink-0`. The two raw-CSS `flex-shrink: 0` declarations in `mdx/Steps.astro` and `WorkExperience.astro` are untouched.
- **Removed a dead `border-opacity-50`** from `RecentTalks.astro`. `border-border` resolves to `border-color: var(--color-border)` and never referenced `--tw-border-opacity`, so the utility had no effect at all. v4 drops `border-opacity-*` entirely.

## Verification

Compared against a build of `main` at the same commit:

- **Declaration-level CSS diff is empty** apart from the two dead `--tw-border-opacity:.5` rules being dropped (2179 -> 2177 rules). Every other declaration block is byte-identical.
- **Selector diff contains only the intended renames** — nothing else moved.
- **All 109 rendered HTML files are byte-identical** after applying the rename map, normalizing per-build asset hashes and Astro island `uid`s.
- `astro check` unchanged at **8 errors / 0 warnings / 42 hints** (all pre-existing).

## Notes

No visual change is expected, and none of the three items alters a rendered declaration.

A `@tailwindcss/upgrade` codemod run was used as a cross-check but deliberately **not** used to produce this diff — it rewrites Tailwind class names inside blog post prose and code samples, including a Tailwind 3 tutorial, and drops words from sentences it misreads as opacity modifiers.